### PR TITLE
PR3: validation phase 1 + step kinds + StartAt

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -25,6 +25,48 @@ var ErrInvalidHeartbeatInterval = errors.New("heartbeat interval must be positiv
 // ErrNilHeartbeatFunc is returned when a HeartbeatConfig has a nil Func.
 var ErrNilHeartbeatFunc = errors.New("heartbeat func must not be nil")
 
+// Structural validation sentinels. All are reported as ValidationProblem
+// fields on *ValidationError when workflow.New runs.
+var (
+	// ErrDuplicateStepName is reported when two steps share a name.
+	ErrDuplicateStepName = errors.New("workflow: duplicate step name")
+	// ErrEmptyStepName is reported when a step has no name.
+	ErrEmptyStepName = errors.New("workflow: empty step name")
+	// ErrUnknownStartStep is reported when Options.StartAt names a step
+	// that does not exist in the workflow.
+	ErrUnknownStartStep = errors.New("workflow: start step not found")
+	// ErrUnknownEdgeTarget is reported when an edge points at a step
+	// that does not exist in the workflow.
+	ErrUnknownEdgeTarget = errors.New("workflow: edge destination not found")
+	// ErrUnknownCatchTarget is reported when a catch handler points at
+	// a step that does not exist in the workflow.
+	ErrUnknownCatchTarget = errors.New("workflow: catch destination not found")
+	// ErrUnknownJoinBranch is reported when JoinConfig.Branches names
+	// a branch that no upstream edge declares.
+	ErrUnknownJoinBranch = errors.New("workflow: join branch not found")
+	// ErrInvalidStepKind is reported when a step mixes multiple step
+	// kinds (activity/join/wait_signal/sleep/pause).
+	ErrInvalidStepKind = errors.New("workflow: conflicting step kinds")
+	// ErrInvalidModifier is reported when a modifier field (Retry,
+	// Catch) is attached to a step kind that cannot use it.
+	ErrInvalidModifier = errors.New("workflow: modifier not allowed on step kind")
+	// ErrInvalidRetryConfig is reported when a RetryConfig has
+	// nonsensical bounds (negative retries, MaxDelay < BaseDelay, etc.).
+	ErrInvalidRetryConfig = errors.New("workflow: invalid retry config")
+	// ErrInvalidSleepConfig is reported when a SleepConfig has a
+	// non-positive Duration.
+	ErrInvalidSleepConfig = errors.New("workflow: invalid sleep config")
+	// ErrInvalidWaitConfig is reported when a WaitSignalConfig has a
+	// missing topic, non-positive timeout, or dangling OnTimeout.
+	ErrInvalidWaitConfig = errors.New("workflow: invalid wait_signal config")
+	// ErrReservedBranchName is reported when a named branch uses the
+	// reserved name "main".
+	ErrReservedBranchName = errors.New("workflow: branch name 'main' is reserved")
+	// ErrDuplicateBranchName is reported when two edges declare the
+	// same branch name.
+	ErrDuplicateBranchName = errors.New("workflow: duplicate branch name")
+)
+
 // Error type constants for classification and matching
 const (
 	// ErrorTypeAll acts as a wildcard that matches any error except fatal errors

--- a/execution_test.go
+++ b/execution_test.go
@@ -1302,7 +1302,7 @@ func TestNamedBranches(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `branch name "same_name" is already used`)
+		require.Contains(t, err.Error(), `duplicate branch name "same_name"`)
 	})
 
 	t.Run("reserved 'main' branch name is rejected", func(t *testing.T) {

--- a/pause_test.go
+++ b/pause_test.go
@@ -447,19 +447,16 @@ func TestPauseStateJSONRoundTrip(t *testing.T) {
 	require.Equal(t, ExecutionStatusPaused, restored.Status)
 }
 
-// TestPauseStepValidationRequiresNext verifies that Workflow.Validate
-// flags a pause step with no Next edges.
+// TestPauseStepValidationRequiresNext verifies that workflow.New
+// rejects a pause step with no Next edges.
 func TestPauseStepValidationRequiresNext(t *testing.T) {
-	wf, err := New(Options{
+	_, err := New(Options{
 		Name: "bad-pause",
 		Steps: []*Step{
 			{Name: "start", Activity: "noop", Next: []*Edge{{Step: "gate"}}},
 			{Name: "gate", Pause: &PauseConfig{}},
 		},
 	})
-	require.NoError(t, err, "New should accept the workflow (validation is explicit)")
-
-	err = wf.Validate()
 	require.Error(t, err)
 	var verr *ValidationError
 	require.True(t, errors.As(err, &verr))

--- a/production_readiness_test.go
+++ b/production_readiness_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -403,17 +404,16 @@ func TestValidateRejectsConflictingStepKinds(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			wf, err := New(Options{
+			_, err := New(Options{
 				Name: "conflict",
 				Steps: []*Step{
 					tc.step,
 					{Name: "after", Activity: "noop"},
 				},
 			})
-			require.NoError(t, err)
-			err = wf.Validate()
 			require.Error(t, err, "should reject conflicting kinds")
-			require.Contains(t, err.Error(), "conflicting kinds")
+			require.Contains(t, err.Error(), "conflicting step kinds")
+			require.True(t, errors.Is(err, ErrInvalidStepKind))
 		})
 	}
 }

--- a/sleep_test.go
+++ b/sleep_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -235,18 +236,17 @@ func TestSleepPauseFreezesClock(t *testing.T) {
 }
 
 // TestSleepStepValidation verifies the sleep step is rejected at
-// Validate time when Duration is zero or negative.
+// workflow.New time when Duration is zero or negative.
 func TestSleepStepValidation(t *testing.T) {
-	wf, err := New(Options{
+	_, err := New(Options{
 		Name: "bad-sleep",
 		Steps: []*Step{
 			{Name: "nap", Sleep: &SleepConfig{Duration: 0}, Next: []*Edge{{Step: "after"}}},
 			{Name: "after", Activity: "noop"},
 		},
 	})
-	require.NoError(t, err)
-	err = wf.Validate()
 	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidSleepConfig))
 }
 
 // TestSleepWaitStateJSONRoundTrip confirms the new Remaining field

--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -13,6 +14,11 @@ type ValidationProblem struct {
 
 	// Message describes the problem.
 	Message string
+
+	// Err is the sentinel error associated with this problem, if any.
+	// Callers can use errors.Is against the enclosing *ValidationError
+	// to test for specific problem classes (ErrDuplicateStepName, etc.).
+	Err error
 }
 
 func (p ValidationProblem) String() string {
@@ -36,91 +42,67 @@ func (e *ValidationError) Error() string {
 	return b.String()
 }
 
-// Validate checks the workflow for structural problems: unreachable steps,
-// invalid join configurations, and dangling catch handler references.
+// Is reports whether err matches any sentinel attached to one of the
+// contained problems. This makes errors.Is(err, ErrDuplicateStepName)
+// work against a ValidationError containing a duplicate-name problem.
+func (e *ValidationError) Is(target error) bool {
+	for _, p := range e.Problems {
+		if p.Err != nil && errors.Is(p.Err, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate checks the workflow for structural problems.
 //
-// Returns nil if the workflow is valid. Returns *ValidationError if problems
-// are found. Call this at registration/startup time to fail fast.
+// Structural validation does not consult the activity registry or the
+// script compiler — those binding-level checks run at NewExecution
+// time. Validate collects every problem it finds into a
+// *ValidationError rather than failing on the first one.
 //
-// Validate does not check activity names. Activity mismatches surface
-// immediately at runtime when the step executes, and validating them here
-// would require passing activities before they're available.
+// This runs automatically as part of workflow.New. It is also exposed
+// for tools (editors, linters) that want to validate a workflow
+// without constructing one.
 func (w *Workflow) Validate() error {
 	var problems []ValidationProblem
-
-	// 1. Reachability: all steps reachable from start via BFS
-	reachable := w.reachableSteps()
-	for _, step := range w.steps {
-		if !reachable[step.Name] {
-			problems = append(problems, ValidationProblem{
-				Step:    step.Name,
-				Message: "unreachable from start step",
-			})
-		}
+	add := func(step, msg string, sentinel error) {
+		problems = append(problems, ValidationProblem{
+			Step:    step,
+			Message: msg,
+			Err:     sentinel,
+		})
 	}
 
-	// 2. Join configuration validity
+	// 1. Edge targets, branch name uniqueness, reserved names.
+	usedBranchNames := map[string]bool{}
 	for _, step := range w.steps {
-		if step.Join == nil {
-			continue
-		}
-		for _, branch := range step.Join.Branches {
-			if !w.pathExists(branch) {
-				problems = append(problems, ValidationProblem{
-					Step:    step.Name,
-					Message: fmt.Sprintf("join references unknown branch %q", branch),
-				})
+		for _, edge := range step.Next {
+			if _, ok := w.stepsByName[edge.Step]; !ok {
+				add(step.Name,
+					fmt.Sprintf("edge destination %q not found", edge.Step),
+					ErrUnknownEdgeTarget)
 			}
-		}
-	}
-
-	// 3. Catch handler next-step validity
-	for _, step := range w.steps {
-		for _, c := range step.Catch {
-			if _, ok := w.stepsByName[c.Next]; !ok {
-				problems = append(problems, ValidationProblem{
-					Step:    step.Name,
-					Message: fmt.Sprintf("catch handler references unknown step %q", c.Next),
-				})
+			if edge.BranchName == "" {
+				continue
 			}
+			if edge.BranchName == "main" {
+				add(step.Name,
+					fmt.Sprintf("branch name 'main' is reserved (edge to %q)", edge.Step),
+					ErrReservedBranchName)
+				continue
+			}
+			if usedBranchNames[edge.BranchName] {
+				add(step.Name,
+					fmt.Sprintf("duplicate branch name %q", edge.BranchName),
+					ErrDuplicateBranchName)
+				continue
+			}
+			usedBranchNames[edge.BranchName] = true
 		}
 	}
 
-	// 4. Pause step configuration validity. A pause step is a hold
-	// gate with a single-choice successor; it must declare at least
-	// one Next edge so the branch has somewhere to go on unpause.
-	for _, step := range w.steps {
-		if step.Pause == nil {
-			continue
-		}
-		if len(step.Next) == 0 {
-			problems = append(problems, ValidationProblem{
-				Step:    step.Name,
-				Message: "pause: at least one Next edge is required",
-			})
-		}
-	}
-
-	// 4a. Sleep step configuration validity. A sleep step must have
-	// a positive Duration. Zero or negative is always a bug.
-	for _, step := range w.steps {
-		if step.Sleep == nil {
-			continue
-		}
-		if step.Sleep.Duration <= 0 {
-			problems = append(problems, ValidationProblem{
-				Step:    step.Name,
-				Message: "sleep: positive Duration is required",
-			})
-		}
-	}
-
-	// 4b. Step kind exclusivity. A step is exactly one of: activity,
-	// join, wait_signal, sleep, or pause. Mixing kinds is always a
-	// programmer error — at runtime the engine dispatches by handler
-	// precedence (join > wait_signal > sleep > pause > activity), so
-	// silently ignored fields would be impossible to debug. Fail
-	// loudly at validate time.
+	// 2. Step kind exclusivity.
 	for _, step := range w.steps {
 		var kinds []string
 		if step.Activity != "" {
@@ -139,37 +121,118 @@ func (w *Workflow) Validate() error {
 			kinds = append(kinds, "pause")
 		}
 		if len(kinds) > 1 {
-			problems = append(problems, ValidationProblem{
-				Step:    step.Name,
-				Message: fmt.Sprintf("step has conflicting kinds %v — a step is exactly one of: activity, join, wait_signal, sleep, pause", kinds),
-			})
+			add(step.Name,
+				fmt.Sprintf("conflicting step kinds %v — a step is exactly one of: activity, join, wait_signal, sleep, pause", kinds),
+				ErrInvalidStepKind)
 		}
 	}
 
-	// 5. WaitSignal configuration validity
+	// 3. Modifier validity — retry/catch only on activity or wait_signal
+	// steps. Pause/sleep/join cannot fail in a way a retry or catch could
+	// meaningfully handle.
+	for _, step := range w.steps {
+		isActivityOrWait := step.Activity != "" || step.WaitSignal != nil
+		if !isActivityOrWait {
+			if len(step.Retry) > 0 {
+				add(step.Name, "retry is only valid on activity or wait_signal steps", ErrInvalidModifier)
+			}
+			if len(step.Catch) > 0 {
+				add(step.Name, "catch is only valid on activity or wait_signal steps", ErrInvalidModifier)
+			}
+		}
+	}
+
+	// 4. Join configuration validity.
+	for _, step := range w.steps {
+		if step.Join == nil {
+			continue
+		}
+		for _, branch := range step.Join.Branches {
+			if !w.branchExists(branch) {
+				add(step.Name,
+					fmt.Sprintf("join references unknown branch %q", branch),
+					ErrUnknownJoinBranch)
+			}
+		}
+	}
+
+	// 5. Catch handler next-step validity.
+	for _, step := range w.steps {
+		for _, c := range step.Catch {
+			if _, ok := w.stepsByName[c.Next]; !ok {
+				add(step.Name,
+					fmt.Sprintf("catch handler references unknown step %q", c.Next),
+					ErrUnknownCatchTarget)
+			}
+		}
+	}
+
+	// 6. Pause step configuration validity.
+	for _, step := range w.steps {
+		if step.Pause == nil {
+			continue
+		}
+		if len(step.Next) == 0 {
+			add(step.Name, "pause: at least one Next edge is required", ErrInvalidStepKind)
+		}
+	}
+
+	// 7. Sleep configuration validity.
+	for _, step := range w.steps {
+		if step.Sleep == nil {
+			continue
+		}
+		if step.Sleep.Duration <= 0 {
+			add(step.Name, "sleep: positive Duration is required", ErrInvalidSleepConfig)
+		}
+	}
+
+	// 8. WaitSignal configuration validity.
 	for _, step := range w.steps {
 		ws := step.WaitSignal
 		if ws == nil {
 			continue
 		}
 		if ws.Topic == "" {
-			problems = append(problems, ValidationProblem{
-				Step:    step.Name,
-				Message: "wait_signal: topic is required",
-			})
+			add(step.Name, "wait_signal: topic is required", ErrInvalidWaitConfig)
 		}
 		if ws.Timeout <= 0 {
-			problems = append(problems, ValidationProblem{
-				Step:    step.Name,
-				Message: "wait_signal: positive timeout is required",
-			})
+			add(step.Name, "wait_signal: positive timeout is required", ErrInvalidWaitConfig)
 		}
 		if ws.OnTimeout != "" {
 			if _, ok := w.stepsByName[ws.OnTimeout]; !ok {
-				problems = append(problems, ValidationProblem{
-					Step:    step.Name,
-					Message: fmt.Sprintf("wait_signal: OnTimeout target %q not found", ws.OnTimeout),
-				})
+				add(step.Name,
+					fmt.Sprintf("wait_signal: OnTimeout target %q not found", ws.OnTimeout),
+					ErrInvalidWaitConfig)
+			}
+		}
+	}
+
+	// 9. Retry configuration sanity.
+	for _, step := range w.steps {
+		for i, rc := range step.Retry {
+			if rc == nil {
+				continue
+			}
+			if rc.MaxRetries < 0 {
+				add(step.Name,
+					fmt.Sprintf("retry[%d]: MaxRetries must be >= 0", i),
+					ErrInvalidRetryConfig)
+			}
+			if rc.BaseDelay < 0 || rc.MaxDelay < 0 {
+				add(step.Name,
+					fmt.Sprintf("retry[%d]: delays must be >= 0", i),
+					ErrInvalidRetryConfig)
+			}
+			if rc.MaxDelay > 0 && rc.BaseDelay > rc.MaxDelay {
+				add(step.Name,
+					fmt.Sprintf("retry[%d]: BaseDelay (%s) > MaxDelay (%s)", i, rc.BaseDelay, rc.MaxDelay),
+					ErrInvalidRetryConfig)
+			}
+			if rc.BackoffRate < 0 {
+				add(step.Name,
+					fmt.Sprintf("retry[%d]: BackoffRate must be >= 0", i),
+					ErrInvalidRetryConfig)
 			}
 		}
 	}
@@ -180,56 +243,8 @@ func (w *Workflow) Validate() error {
 	return nil
 }
 
-// reachableSteps returns the set of step names reachable from the start step.
-func (w *Workflow) reachableSteps() map[string]bool {
-	reachable := make(map[string]bool)
-	if w.start == nil {
-		return reachable
-	}
-
-	queue := []*Step{w.start}
-	reachable[w.start.Name] = true
-
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-
-		// Follow edges
-		for _, edge := range current.Next {
-			if !reachable[edge.Step] {
-				if step, ok := w.stepsByName[edge.Step]; ok {
-					reachable[edge.Step] = true
-					queue = append(queue, step)
-				}
-			}
-		}
-
-		// Follow catch handler targets
-		for _, c := range current.Catch {
-			if !reachable[c.Next] {
-				if step, ok := w.stepsByName[c.Next]; ok {
-					reachable[c.Next] = true
-					queue = append(queue, step)
-				}
-			}
-		}
-
-		// Follow wait_signal OnTimeout target
-		if current.WaitSignal != nil && current.WaitSignal.OnTimeout != "" {
-			if !reachable[current.WaitSignal.OnTimeout] {
-				if step, ok := w.stepsByName[current.WaitSignal.OnTimeout]; ok {
-					reachable[current.WaitSignal.OnTimeout] = true
-					queue = append(queue, step)
-				}
-			}
-		}
-	}
-
-	return reachable
-}
-
-// pathExists returns whether a named branch is defined on any edge in the workflow.
-func (w *Workflow) pathExists(name string) bool {
+// branchExists returns whether a named branch is defined on any edge.
+func (w *Workflow) branchExists(name string) bool {
 	for _, step := range w.steps {
 		for _, edge := range step.Next {
 			if edge.BranchName == name {

--- a/validate_test.go
+++ b/validate_test.go
@@ -19,29 +19,8 @@ func TestValidatePassesForValidWorkflow(t *testing.T) {
 	require.NoError(t, wf.Validate())
 }
 
-func TestValidateDetectsUnreachableStep(t *testing.T) {
-	wf, err := New(Options{
-		Name: "unreachable",
-		Steps: []*Step{
-			{Name: "start", Activity: "a"},
-			// "orphan" is defined but no edge leads to it
-			{Name: "orphan", Activity: "b"},
-		},
-	})
-	require.NoError(t, err)
-
-	err = wf.Validate()
-	require.Error(t, err)
-
-	var ve *ValidationError
-	require.True(t, errors.As(err, &ve))
-	require.Len(t, ve.Problems, 1)
-	require.Equal(t, "orphan", ve.Problems[0].Step)
-	require.Contains(t, ve.Problems[0].Message, "unreachable")
-}
-
 func TestValidateDetectsBadCatchReference(t *testing.T) {
-	wf, err := New(Options{
+	_, err := New(Options{
 		Name: "bad-catch",
 		Steps: []*Step{
 			{
@@ -53,19 +32,17 @@ func TestValidateDetectsBadCatchReference(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	err = wf.Validate()
 	require.Error(t, err)
 
 	var ve *ValidationError
 	require.True(t, errors.As(err, &ve))
 	require.Len(t, ve.Problems, 1)
 	require.Contains(t, ve.Problems[0].Message, `unknown step "ghost"`)
+	require.True(t, errors.Is(err, ErrUnknownCatchTarget))
 }
 
 func TestValidateDetectsBadJoinBranch(t *testing.T) {
-	wf, err := New(Options{
+	_, err := New(Options{
 		Name: "bad-join",
 		Steps: []*Step{
 			{
@@ -83,9 +60,6 @@ func TestValidateDetectsBadJoinBranch(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-
-	err = wf.Validate()
 	require.Error(t, err)
 
 	var ve *ValidationError
@@ -99,10 +73,11 @@ func TestValidateDetectsBadJoinBranch(t *testing.T) {
 		}
 	}
 	require.True(t, found, "should report bad join branch")
+	require.True(t, errors.Is(err, ErrUnknownJoinBranch))
 }
 
 func TestValidateReportsMultipleProblems(t *testing.T) {
-	wf, err := New(Options{
+	_, err := New(Options{
 		Name: "multi-problems",
 		Steps: []*Step{
 			{
@@ -111,22 +86,19 @@ func TestValidateReportsMultipleProblems(t *testing.T) {
 				Catch: []*CatchConfig{
 					{ErrorEquals: []string{"all"}, Next: "nonexistent"},
 				},
+				Retry: []*RetryConfig{{MaxRetries: -1}},
 			},
-			{Name: "island", Activity: "b"}, // unreachable
 		},
 	})
-	require.NoError(t, err)
-
-	err = wf.Validate()
 	require.Error(t, err)
 
 	var ve *ValidationError
 	require.True(t, errors.As(err, &ve))
-	require.GreaterOrEqual(t, len(ve.Problems), 2, "should find both unreachable step and bad catch ref")
+	require.GreaterOrEqual(t, len(ve.Problems), 2, "should find both retry and bad catch ref")
 }
 
 func TestValidateStepReachableViaCatch(t *testing.T) {
-	// A step only reachable via a catch handler should be considered reachable
+	// Reachability is no longer enforced — this still builds successfully.
 	wf, err := New(Options{
 		Name: "catch-reachable",
 		Steps: []*Step{
@@ -141,5 +113,76 @@ func TestValidateStepReachableViaCatch(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, wf.Validate(), "recovery step should be reachable via catch")
+	require.NoError(t, wf.Validate())
+}
+
+func TestValidateRejectsDuplicateStepName(t *testing.T) {
+	_, err := New(Options{
+		Name: "dupe",
+		Steps: []*Step{
+			{Name: "a", Activity: "x"},
+			{Name: "a", Activity: "y"},
+		},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrDuplicateStepName))
+}
+
+func TestValidateRejectsUnknownStartAt(t *testing.T) {
+	_, err := New(Options{
+		Name:    "bad-start",
+		StartAt: "ghost",
+		Steps: []*Step{
+			{Name: "a", Activity: "x"},
+		},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrUnknownStartStep))
+}
+
+func TestValidateAcceptsExplicitStartAt(t *testing.T) {
+	wf, err := New(Options{
+		Name:    "explicit-start",
+		StartAt: "b",
+		Steps: []*Step{
+			{Name: "a", Activity: "x"},
+			{Name: "b", Activity: "y"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "b", wf.Start().Name)
+}
+
+func TestValidateRejectsInvalidRetryConfig(t *testing.T) {
+	_, err := New(Options{
+		Name: "bad-retry",
+		Steps: []*Step{
+			{
+				Name:     "a",
+				Activity: "x",
+				Retry: []*RetryConfig{
+					{MaxRetries: -1},
+				},
+			},
+		},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidRetryConfig))
+}
+
+func TestValidateRejectsModifierOnPauseStep(t *testing.T) {
+	_, err := New(Options{
+		Name: "bad-pause-retry",
+		Steps: []*Step{
+			{
+				Name:  "gate",
+				Pause: &PauseConfig{},
+				Retry: []*RetryConfig{{MaxRetries: 1}},
+				Next:  []*Edge{{Step: "done"}},
+			},
+			{Name: "done", Activity: "x"},
+		},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidModifier))
 }

--- a/workflow.go
+++ b/workflow.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 )
@@ -19,8 +20,8 @@ func (i *Input) IsRequired() bool {
 
 // Output defines a workflow output parameter
 type Output struct {
-	Name        string `json:"name" yaml:"name"`
-	Variable    string `json:"variable" yaml:"variable"`
+	Name     string `json:"name" yaml:"name"`
+	Variable string `json:"variable" yaml:"variable"`
 	// Branch names the execution branch to extract the output value from.
 	// Defaults to "main" when empty.
 	Branch      string `json:"branch,omitempty" yaml:"branch,omitempty"`
@@ -35,6 +36,10 @@ type Options struct {
 	Inputs      []*Input       `json:"inputs,omitempty" yaml:"inputs,omitempty"`
 	Outputs     []*Output      `json:"outputs,omitempty" yaml:"outputs,omitempty"`
 	State       map[string]any `json:"state,omitempty" yaml:"state,omitempty"`
+	// StartAt names the step that the first execution branch begins on.
+	// When empty, the first step in Steps is the start step. Validated
+	// at New() time to reference an existing step.
+	StartAt string `json:"start_at,omitempty" yaml:"start_at,omitempty"`
 }
 
 // Workflow defines a repeatable process as a graph of steps to be executed.
@@ -50,6 +55,12 @@ type Workflow struct {
 }
 
 // New returns a new Workflow configured with the given options.
+//
+// New runs structural validation and fails fast on any problem it
+// finds, returning a *ValidationError with the full list of problems.
+// Structural validation does not consult the activity registry or
+// the script compiler — that binding-layer validation runs during
+// NewExecution.
 func New(opts Options) (*Workflow, error) {
 	if opts.Name == "" {
 		return nil, fmt.Errorf("workflow name required")
@@ -58,30 +69,63 @@ func New(opts Options) (*Workflow, error) {
 		return nil, fmt.Errorf("steps required")
 	}
 
-	// Build stepsByName map
 	stepsByName := make(map[string]*Step, len(opts.Steps))
+	var dupes []ValidationProblem
 	for _, step := range opts.Steps {
 		if step.Name == "" {
-			return nil, fmt.Errorf("step name required")
+			dupes = append(dupes, ValidationProblem{
+				Message: "empty step name",
+				Err:     ErrEmptyStepName,
+			})
+			continue
+		}
+		if _, exists := stepsByName[step.Name]; exists {
+			dupes = append(dupes, ValidationProblem{
+				Step:    step.Name,
+				Message: fmt.Sprintf("duplicate step name %q", step.Name),
+				Err:     ErrDuplicateStepName,
+			})
+			continue
 		}
 		stepsByName[step.Name] = step
 	}
 
-	// Validate the workflow structure
-	if err := validateWorkflowSteps(stepsByName); err != nil {
-		return nil, fmt.Errorf("workflow validation failed: %w", err)
+	start := opts.Steps[0]
+	if opts.StartAt != "" {
+		if s, ok := stepsByName[opts.StartAt]; ok {
+			start = s
+		} else {
+			dupes = append(dupes, ValidationProblem{
+				Message: fmt.Sprintf("start step %q not found", opts.StartAt),
+				Err:     ErrUnknownStartStep,
+			})
+		}
 	}
 
-	return &Workflow{
+	wf := &Workflow{
 		name:         opts.Name,
 		description:  opts.Description,
 		inputs:       opts.Inputs,
 		outputs:      opts.Outputs,
 		steps:        opts.Steps,
 		stepsByName:  stepsByName,
-		start:        opts.Steps[0],
+		start:        start,
 		initialState: opts.State,
-	}, nil
+	}
+
+	if err := wf.Validate(); err != nil {
+		// Merge duplicate-name problems found while building stepsByName.
+		var ve *ValidationError
+		if errors.As(err, &ve) && len(dupes) > 0 {
+			ve.Problems = append(dupes, ve.Problems...)
+			return nil, ve
+		}
+		return nil, err
+	}
+	if len(dupes) > 0 {
+		return nil, &ValidationError{Problems: dupes}
+	}
+	return wf, nil
 }
 
 // Name returns the workflow name
@@ -133,31 +177,4 @@ func (w *Workflow) StepNames() []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-// validateWorkflowSteps validates the workflow step structure
-func validateWorkflowSteps(stepsByName map[string]*Step) error {
-	usedBranchNames := map[string]bool{}
-	for _, step := range stepsByName {
-		if step.Name == "" {
-			return fmt.Errorf("empty step name detected")
-		}
-		for _, edge := range step.Next {
-			if _, ok := stepsByName[edge.Step]; !ok {
-				return fmt.Errorf("invalid edge detected on step %q: destination step %q not found",
-					step.Name, edge.Step)
-			}
-			// Confirm reserved branch names are not used
-			if edge.BranchName != "" {
-				if edge.BranchName == "main" {
-					return fmt.Errorf("branch name 'main' is reserved and cannot be used in step %q", step.Name)
-				}
-				if usedBranchNames[edge.BranchName] {
-					return fmt.Errorf("branch name %q is already used", edge.BranchName)
-				}
-				usedBranchNames[edge.BranchName] = true
-			}
-		}
-	}
-	return nil
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -69,6 +69,6 @@ func TestInvalidWorkflows(t *testing.T) {
 			Steps: []*Step{{Name: ""}},
 		})
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "step name required")
+		require.Contains(t, err.Error(), "empty step name")
 	})
 }


### PR DESCRIPTION
## Summary

Third PR in the v1 cleanup (§PR3). `workflow.New` now runs structural validation eagerly and fails fast with a `*ValidationError`. No registry or compiler required — that's phase 2 (PR5).

- New `Options.StartAt` field.
- Retry/catch modifier rejection on non-activity, non-wait_signal steps.
- RetryConfig sanity checks.
- `ValidationProblem.Err` sentinel + `*ValidationError.Is` for `errors.Is` support.
- Removed unreachable-step check (warn-don't-error posture per plan).

New error sentinels: `ErrDuplicateStepName`, `ErrEmptyStepName`, `ErrUnknownStartStep`, `ErrUnknownEdgeTarget`, `ErrUnknownCatchTarget`, `ErrUnknownJoinBranch`, `ErrInvalidStepKind`, `ErrInvalidModifier`, `ErrInvalidRetryConfig`, `ErrInvalidSleepConfig`, `ErrInvalidWaitConfig`, `ErrReservedBranchName`, `ErrDuplicateBranchName`.

## Test plan

- [x] \`make test-all\` green
- [x] New validate tests cover duplicate steps, StartAt, retry bounds, modifier-on-pause

🤖 Generated with [Claude Code](https://claude.com/claude-code)