### PR TITLE
PR4: ActivityRegistry, functional options, single Execute

### DIFF
--- a/activities/child_workflow_activity_test.go
+++ b/activities/child_workflow_activity_test.go
@@ -23,7 +23,7 @@ func TestChildWorkflowActivity(t *testing.T) {
 		reg := workflow.NewMemoryWorkflowRegistry()
 		reg.Register(wf)
 
-		greetAct := workflow.NewActivityFunction("greet", func(ctx workflow.Context, params map[string]any) (any, error) {
+		greetAct := workflow.ActivityFunc("greet", func(ctx workflow.Context, params map[string]any) (any, error) {
 			ctx.SetVariable("greeting", "hello from child")
 			return "hello", nil
 		})
@@ -55,7 +55,7 @@ func TestChildWorkflowActivity(t *testing.T) {
 		reg := workflow.NewMemoryWorkflowRegistry()
 		reg.Register(wf)
 
-		workAct := workflow.NewActivityFunction("work", func(ctx workflow.Context, params map[string]any) (any, error) {
+		workAct := workflow.ActivityFunc("work", func(ctx workflow.Context, params map[string]any) (any, error) {
 			return "done", nil
 		})
 

--- a/activity.go
+++ b/activity.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 )
 
-// ActivityRegistry contains activities indexed by name.
-type ActivityRegistry map[string]Activity
-
 // ExecuteActivityFunc is the signature for an Activity execution function.
 type ExecuteActivityFunc func(ctx Context, parameters map[string]any) (any, error)
 

--- a/activity_functions.go
+++ b/activity_functions.go
@@ -4,63 +4,64 @@ import "reflect"
 
 // Confirm the interfaces are implemented correctly.
 var (
-	_ Activity                = (*ActivityFunction)(nil)
-	_ TypedActivity[any, any] = (*TypedActivityFunction[any, any])(nil)
+	_ Activity                = (*activityFunc)(nil)
+	_ TypedActivity[any, any] = (*typedActivityFunc[any, any])(nil)
 )
 
-// ActivityFunction wraps a function for use as an Activity. It implements the
-// workflow.Activity interface.
-type ActivityFunction struct {
+// activityFunc wraps a function for use as an Activity.
+type activityFunc struct {
 	name string
 	fn   ExecuteActivityFunc
 }
 
-// NewActivityFunction returns an Activity for the given function.
-func NewActivityFunction(name string, fn ExecuteActivityFunc) Activity {
-	return &ActivityFunction{name: name, fn: fn}
+// ActivityFunc returns an Activity backed by fn. The returned value
+// implements the Activity interface, mirroring http.HandlerFunc.
+func ActivityFunc(name string, fn ExecuteActivityFunc) Activity {
+	return &activityFunc{name: name, fn: fn}
 }
 
 // Name of the Activity.
-func (a *ActivityFunction) Name() string {
+func (a *activityFunc) Name() string {
 	return a.name
 }
 
 // Execute the Activity.
-func (a *ActivityFunction) Execute(ctx Context, parameters map[string]any) (any, error) {
+func (a *activityFunc) Execute(ctx Context, parameters map[string]any) (any, error) {
 	return a.fn(ctx, parameters)
 }
 
-// NewTypedActivityFunction wraps a function for use as a TypedActivity. It
-// implements the workflow.TypedActivity interface.
-func NewTypedActivityFunction[TParams, TResult any](name string, fn func(ctx Context, params TParams) (TResult, error)) Activity {
-	return NewTypedActivity(&TypedActivityFunction[TParams, TResult]{
+// TypedActivityFunc returns an Activity backed by a strongly-typed
+// function. Parameters are JSON-marshalled into TParams by the adapter
+// layer.
+func TypedActivityFunc[TParams, TResult any](name string, fn func(ctx Context, params TParams) (TResult, error)) Activity {
+	return NewTypedActivity(&typedActivityFunc[TParams, TResult]{
 		name: name,
 		fn:   fn,
 	})
 }
 
-// TypedActivityFunction is a helper struct for creating typed activities from functions
-type TypedActivityFunction[TParams, TResult any] struct {
+// typedActivityFunc is the internal struct backing TypedActivityFunc.
+type typedActivityFunc[TParams, TResult any] struct {
 	name string
 	fn   func(ctx Context, params TParams) (TResult, error)
 }
 
 // Name of the Activity.
-func (t *TypedActivityFunction[TParams, TResult]) Name() string {
+func (t *typedActivityFunc[TParams, TResult]) Name() string {
 	return t.name
 }
 
 // Execute the Activity.
-func (t *TypedActivityFunction[TParams, TResult]) Execute(ctx Context, params TParams) (TResult, error) {
+func (t *typedActivityFunc[TParams, TResult]) Execute(ctx Context, params TParams) (TResult, error) {
 	return t.fn(ctx, params)
 }
 
 // ParametersType returns the type of the parameters for the Activity.
-func (t *TypedActivityFunction[TParams, TResult]) ParametersType() reflect.Type {
+func (t *typedActivityFunc[TParams, TResult]) ParametersType() reflect.Type {
 	return reflect.TypeOf((*TParams)(nil)).Elem()
 }
 
 // ResultType returns the type of the result for the Activity.
-func (t *TypedActivityFunction[TParams, TResult]) ResultType() reflect.Type {
+func (t *typedActivityFunc[TParams, TResult]) ResultType() reflect.Type {
 	return reflect.TypeOf((*TResult)(nil)).Elem()
 }

--- a/activity_functions_test.go
+++ b/activity_functions_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestActivityFunction(t *testing.T) {
-	activity := NewActivityFunction(
+	activity := ActivityFunc(
 		"marshal",
 		func(ctx Context, parameters map[string]any) (any, error) {
 			data, err := json.Marshal(parameters)
@@ -48,7 +48,7 @@ func TestTypedActivityFunction(t *testing.T) {
 		Name string `json:"name"`
 	}
 
-	activity := NewTypedActivityFunction(
+	activity := TypedActivityFunc(
 		"marshal",
 		func(ctx Context, person Person) (string, error) {
 			data, err := json.Marshal(person)
@@ -76,7 +76,7 @@ func TestTypedActivityFunction(t *testing.T) {
 	adapter, ok := activity.(*TypedActivityAdapter[Person, string])
 	require.True(t, ok)
 
-	typedFunc, ok := adapter.Activity().(*TypedActivityFunction[Person, string])
+	typedFunc, ok := adapter.Activity().(*typedActivityFunc[Person, string])
 	require.True(t, ok)
 
 	require.Equal(t, reflect.TypeOf(Person{}), typedFunc.ParametersType())

--- a/activity_history_test.go
+++ b/activity_history_test.go
@@ -25,7 +25,7 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 		invocations int32
 	)
 
-	agent := NewActivityFunction("agent", func(ctx Context, p map[string]any) (any, error) {
+	agent := ActivityFunc("agent", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		history := ActivityHistory(ctx)
 
@@ -70,12 +70,12 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{agent},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(agent)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -100,15 +100,15 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 	// Deliver the signal and resume.
 	require.NoError(t, signals.Send(ctx, execID, topic, "reply-payload"))
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{agent},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(agent)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 
@@ -140,7 +140,7 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 // PRD's semantics: caching is for successful results, not failures.
 func TestActivityHistoryErrorNotCached(t *testing.T) {
 	var calls int32
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		history := ActivityHistory(ctx)
 
 		// First call fails.
@@ -167,10 +167,9 @@ func TestActivityHistoryErrorNotCached(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{noop},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -188,7 +187,7 @@ func TestActivityHistoryErrorNotCached(t *testing.T) {
 func TestActivityHistoryScopedPerStep(t *testing.T) {
 	var aCalls, bCalls int32
 
-	stepA := NewActivityFunction("a", func(ctx Context, p map[string]any) (any, error) {
+	stepA := ActivityFunc("a", func(ctx Context, p map[string]any) (any, error) {
 		history := ActivityHistory(ctx)
 		_, err := history.RecordOrReplay("work", func() (any, error) {
 			atomic.AddInt32(&aCalls, 1)
@@ -196,7 +195,7 @@ func TestActivityHistoryScopedPerStep(t *testing.T) {
 		})
 		return "a-done", err
 	})
-	stepB := NewActivityFunction("b", func(ctx Context, p map[string]any) (any, error) {
+	stepB := ActivityFunc("b", func(ctx Context, p map[string]any) (any, error) {
 		history := ActivityHistory(ctx)
 		// Same key as step A — should NOT be cached, since history is
 		// scoped per step.
@@ -216,10 +215,10 @@ func TestActivityHistoryScopedPerStep(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{stepA, stepB},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(stepA)
+	reg.MustRegister(stepB)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/activity_registry.go
+++ b/activity_registry.go
@@ -1,0 +1,74 @@
+package workflow
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// ErrDuplicateActivity is returned when Register is called with an
+// activity name that has already been registered.
+var ErrDuplicateActivity = errors.New("workflow: duplicate activity registration")
+
+// ActivityRegistry owns the set of activities an Execution can call
+// by name. It is opaque — consumers construct one via
+// NewActivityRegistry and add activities through Register or
+// MustRegister. The registry is read-only once passed to NewExecution.
+type ActivityRegistry struct {
+	activities map[string]Activity
+}
+
+// NewActivityRegistry returns an empty registry.
+func NewActivityRegistry() *ActivityRegistry {
+	return &ActivityRegistry{activities: map[string]Activity{}}
+}
+
+// Register adds an activity to the registry. Returns ErrDuplicateActivity
+// if an activity with the same name is already registered.
+func (r *ActivityRegistry) Register(a Activity) error {
+	if a == nil {
+		return fmt.Errorf("workflow: nil activity")
+	}
+	name := a.Name()
+	if name == "" {
+		return fmt.Errorf("workflow: activity has empty name")
+	}
+	if _, exists := r.activities[name]; exists {
+		return fmt.Errorf("%w: %q", ErrDuplicateActivity, name)
+	}
+	r.activities[name] = a
+	return nil
+}
+
+// MustRegister panics on registration failure. Returns the registry so
+// calls can chain in init() or a builder expression.
+func (r *ActivityRegistry) MustRegister(a Activity) *ActivityRegistry {
+	if err := r.Register(a); err != nil {
+		panic(err)
+	}
+	return r
+}
+
+// Get returns the activity registered under name, if any.
+func (r *ActivityRegistry) Get(name string) (Activity, bool) {
+	a, ok := r.activities[name]
+	return a, ok
+}
+
+// Names returns the registered activity names in sorted order.
+func (r *ActivityRegistry) Names() []string {
+	names := make([]string, 0, len(r.activities))
+	for name := range r.activities {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// internal accessor for the engine.
+func (r *ActivityRegistry) asMap() map[string]Activity {
+	if r == nil {
+		return nil
+	}
+	return r.activities
+}

--- a/branch_join_test.go
+++ b/branch_join_test.go
@@ -59,35 +59,33 @@ func TestBranchJoining(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					return 10, nil
-				}),
-				NewActivityFunction("double", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("double", func(ctx Context, params map[string]any) (any, error) {
 					value, _ := ctx.GetVariable("value")
 					return value.(int) * 2, nil
-				}),
-				NewActivityFunction("triple", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("triple", func(ctx Context, params map[string]any) (any, error) {
 					value, _ := ctx.GetVariable("value")
 					return value.(int) * 3, nil
-				}),
-				NewActivityFunction("sum", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("sum", func(ctx Context, params map[string]any) (any, error) {
 					doubled, _ := ctx.GetVariable("doubled")
 					tripled, _ := ctx.GetVariable("tripled")
 					return doubled.(int) + tripled.(int), nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run the workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -146,24 +144,21 @@ func TestBranchJoining(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg2 := NewActivityRegistry()
+		reg2.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					return 5, nil
-				}),
-				NewActivityFunction("work_x", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("work_x", func(ctx Context, params map[string]any) (any, error) {
 					ctx.SetVariable("x_meta", "x_processed")
 					base, _ := ctx.GetVariable("base")
 					return base.(int) * 4, nil
-				}),
-				NewActivityFunction("work_y", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("work_y", func(ctx Context, params map[string]any) (any, error) {
 					ctx.SetVariable("y_meta", "y_processed")
 					base, _ := ctx.GetVariable("base")
 					return base.(int) * 6, nil
-				}),
-				NewActivityFunction("combine", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("combine", func(ctx Context, params map[string]any) (any, error) {
 					pathX, _ := ctx.GetVariable("path_x")
 					pathY, _ := ctx.GetVariable("path_y")
 
@@ -177,16 +172,17 @@ func TestBranchJoining(t *testing.T) {
 					require.Equal(t, 30, pathYMap["y_data"]) // 5 * 6
 
 					return pathXMap["x_data"].(int) + pathYMap["y_data"].(int), nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg2,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run the workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 

--- a/child_workflow.go
+++ b/child_workflow.go
@@ -146,27 +146,14 @@ func NewDefaultChildWorkflowExecutor(opts ChildWorkflowExecutorOptions) (*Defaul
 func (e *DefaultChildWorkflowExecutor) ExecuteSync(ctx context.Context, spec *ChildWorkflowSpec) (*ChildWorkflowResult, error) {
 	startTime := time.Now()
 
-	// Get the workflow from registry
 	workflow, exists := e.workflowRegistry.Get(spec.WorkflowName)
 	if !exists {
 		return nil, fmt.Errorf("workflow %q not found in registry", spec.WorkflowName)
 	}
 
-	// Create execution options for the child workflow
-	executionOpts := ExecutionOptions{
-		Workflow:       workflow,
-		Inputs:         spec.Inputs,
-		Activities:     e.activities,
-		ActivityLogger: e.activityLogger,
-		Checkpointer:   e.checkpointer,
-		Logger:         e.logger,
-		ScriptCompiler: e.scriptCompiler,
-	}
-
-	// Create and run the child execution
-	execution, err := NewExecution(executionOpts)
+	execution, err := e.newChildExecution(workflow, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create child execution: %w", err)
+		return nil, err
 	}
 
 	// Apply timeout if specified
@@ -177,51 +164,65 @@ func (e *DefaultChildWorkflowExecutor) ExecuteSync(ctx context.Context, spec *Ch
 		defer cancel()
 	}
 
-	// Run the execution
-	err = execution.Run(execCtx)
+	result, execErr := execution.Execute(execCtx)
 	duration := time.Since(startTime)
 
-	// Prepare result
-	result := &ChildWorkflowResult{
+	cwr := &ChildWorkflowResult{
 		ExecutionID: execution.ID(),
 		Status:      execution.Status(),
 		Duration:    duration,
-		Error:       err,
+		Error:       execErr,
 	}
-
-	// Extract outputs from execution state
-	outputs := execution.GetOutputs()
-	result.Outputs = make(map[string]any, len(outputs))
-	for k, v := range outputs {
-		result.Outputs[k] = v
+	if result != nil {
+		cwr.Outputs = make(map[string]any, len(result.Outputs))
+		for k, v := range result.Outputs {
+			cwr.Outputs[k] = v
+		}
 	}
+	return cwr, execErr
+}
 
-	return result, err
+// newChildExecution builds an Execution for a child workflow using the
+// executor's shared infrastructure (activities, checkpointer, ...).
+func (e *DefaultChildWorkflowExecutor) newChildExecution(wf *Workflow, spec *ChildWorkflowSpec) (*Execution, error) {
+	reg := NewActivityRegistry()
+	for _, a := range e.activities {
+		if err := reg.Register(a); err != nil {
+			return nil, fmt.Errorf("child registry: %w", err)
+		}
+	}
+	opts := []ExecutionOption{
+		WithInputs(spec.Inputs),
+	}
+	if e.activityLogger != nil {
+		opts = append(opts, WithActivityLogger(e.activityLogger))
+	}
+	if e.checkpointer != nil {
+		opts = append(opts, WithCheckpointer(e.checkpointer))
+	}
+	if e.logger != nil {
+		opts = append(opts, WithLogger(e.logger))
+	}
+	if e.scriptCompiler != nil {
+		opts = append(opts, WithScriptCompiler(e.scriptCompiler))
+	}
+	exec, err := NewExecution(wf, reg, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create child execution: %w", err)
+	}
+	return exec, nil
 }
 
 // ExecuteAsync starts a child workflow asynchronously
 func (e *DefaultChildWorkflowExecutor) ExecuteAsync(ctx context.Context, spec *ChildWorkflowSpec) (*ChildWorkflowHandle, error) {
-	// Get the workflow from registry
 	workflow, exists := e.workflowRegistry.Get(spec.WorkflowName)
 	if !exists {
 		return nil, fmt.Errorf("workflow %q not found in registry", spec.WorkflowName)
 	}
 
-	// Create execution options for the child workflow
-	executionOpts := ExecutionOptions{
-		Workflow:       workflow,
-		Inputs:         spec.Inputs,
-		Activities:     e.activities,
-		ActivityLogger: e.activityLogger,
-		Checkpointer:   e.checkpointer,
-		Logger:         e.logger,
-		ScriptCompiler: e.scriptCompiler,
-	}
-
-	// Create the child execution
-	execution, err := NewExecution(executionOpts)
+	execution, err := e.newChildExecution(workflow, spec)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create child execution: %w", err)
+		return nil, err
 	}
 
 	// Track the async execution
@@ -251,7 +252,7 @@ func (e *DefaultChildWorkflowExecutor) ExecuteAsync(ctx context.Context, spec *C
 		}
 
 		// Run the execution (errors will be captured in execution status)
-		execution.Run(execCtx)
+		execution.Execute(execCtx)
 	}()
 
 	return &ChildWorkflowHandle{

--- a/cmd/workflow/main.go
+++ b/cmd/workflow/main.go
@@ -79,7 +79,11 @@ func main() {
 	}
 
 	// Create activity registry with all available activities
-	activityRegistry := createActivityRegistry(config, logger)
+	activityList := createActivityRegistry(config, logger)
+	activityRegistry := workflow.NewActivityRegistry()
+	for _, a := range activityList {
+		activityRegistry.MustRegister(a)
+	}
 
 	// Set up activity logger
 	var activityLogger workflow.ActivityLogger
@@ -104,14 +108,12 @@ func main() {
 
 	// Create execution. ScriptCompiler is left nil so the engine's
 	// default expr compiler handles conditions and ${...} templates.
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:       wf,
-		Inputs:         inputs,
-		Activities:     activityRegistry,
-		Logger:         logger,
-		ActivityLogger: activityLogger,
-		Checkpointer:   checkpointer,
-	})
+	execution, err := workflow.NewExecution(wf, activityRegistry,
+		workflow.WithInputs(inputs),
+		workflow.WithLogger(logger),
+		workflow.WithActivityLogger(activityLogger),
+		workflow.WithCheckpointer(checkpointer),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create execution: %v", err)
 	}
@@ -128,7 +130,7 @@ func main() {
 	info("Starting execution (ID: %s)...", execution.ID())
 
 	startTime := time.Now()
-	err = execution.Run(ctx)
+	_, err = execution.Execute(ctx)
 	duration := time.Since(startTime)
 
 	// Show execution results

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -497,7 +497,7 @@ func TestDefaultChildWorkflowExecutor_ExecuteSync(t *testing.T) {
 	reg := NewMemoryWorkflowRegistry()
 	reg.Register(wf)
 
-	greetActivity := NewActivityFunction("greet", func(ctx Context, params map[string]any) (any, error) {
+	greetActivity := ActivityFunc("greet", func(ctx Context, params map[string]any) (any, error) {
 		ctx.SetVariable("greeting", "hello")
 		return "hello", nil
 	})
@@ -756,21 +756,21 @@ func TestExecution_WithCallbacks(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	greetActivity := NewActivityFunction("greet", func(ctx Context, params map[string]any) (any, error) {
+	greetActivity := ActivityFunc("greet", func(ctx Context, params map[string]any) (any, error) {
 		return "hello", nil
 	})
 
 	cb := &eventTracker{events: &events}
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler:     newTestCompiler(),
-		Workflow:           wf,
-		Activities:         []Activity{greetActivity},
-		ExecutionCallbacks: cb,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(greetActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithExecutionCallbacks(cb),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 
@@ -817,21 +817,21 @@ func TestExecution_WithStepProgressStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	workActivity := NewActivityFunction("work", func(ctx Context, params map[string]any) (any, error) {
+	workActivity := ActivityFunc("work", func(ctx Context, params map[string]any) (any, error) {
 		ReportProgress(ctx, ProgressDetail{Message: "halfway", Data: map[string]any{"pct": 50}})
 		return "done", nil
 	})
 
 	store := &memoryProgressStore{}
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler:    newTestCompiler(),
-		Workflow:          wf,
-		Activities:        []Activity{workActivity},
-		StepProgressStore: store,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(workActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithStepProgressStore(store),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 
 	// Poll until async dispatch completes (at least running + completed)
@@ -876,7 +876,7 @@ func TestExecution_ContextCancelled(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	slowActivity := NewActivityFunction("slow", func(ctx Context, params map[string]any) (any, error) {
+	slowActivity := ActivityFunc("slow", func(ctx Context, params map[string]any) (any, error) {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -885,20 +885,19 @@ func TestExecution_ContextCancelled(t *testing.T) {
 		}
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{slowActivity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(slowActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	err = exec.Run(ctx)
-	require.Error(t, err)
-	// The Run method returns the error but the execution
-	// uses Execute for structured status checking
+	result, err := exec.Execute(ctx)
+	require.NoError(t, err)
+	require.True(t, result.Failed())
 }
 
 // --- Execution.Execute structured result ---
@@ -915,16 +914,16 @@ func TestExecution_Execute(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	echoActivity := NewActivityFunction("echo", func(ctx Context, params map[string]any) (any, error) {
+	echoActivity := ActivityFunc("echo", func(ctx Context, params map[string]any) (any, error) {
 		ctx.SetVariable("msg", "hello")
 		return "hello", nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{echoActivity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(echoActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
 	result, err := exec.Execute(context.Background())
@@ -963,7 +962,7 @@ func TestDefaultChildWorkflowExecutor_AsyncFlow(t *testing.T) {
 	reg := NewMemoryWorkflowRegistry()
 	reg.Register(wf)
 
-	greetActivity := NewActivityFunction("greet", func(ctx Context, params map[string]any) (any, error) {
+	greetActivity := ActivityFunc("greet", func(ctx Context, params map[string]any) (any, error) {
 		ctx.SetVariable("msg", "async hello")
 		return "done", nil
 	})
@@ -1035,22 +1034,23 @@ func TestExecution_Branching(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	setFlag := NewActivityFunction("set-flag", func(ctx Context, params map[string]any) (any, error) {
+	setFlag := ActivityFunc("set-flag", func(ctx Context, params map[string]any) (any, error) {
 		ctx.SetVariable("flag", true)
 		return nil, nil
 	})
-	noop := NewActivityFunction("noop", func(ctx Context, params map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, params map[string]any) (any, error) {
 		return nil, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{setFlag, noop},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(setFlag)
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 }
@@ -1075,25 +1075,27 @@ func TestExecution_CatchHandler(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	failIt := NewActivityFunction("fail-it", func(ctx Context, params map[string]any) (any, error) {
+	failIt := ActivityFunc("fail-it", func(ctx Context, params map[string]any) (any, error) {
 		return nil, fmt.Errorf("something broke")
 	})
-	recoverIt := NewActivityFunction("recover-it", func(ctx Context, params map[string]any) (any, error) {
+	recoverIt := ActivityFunc("recover-it", func(ctx Context, params map[string]any) (any, error) {
 		ctx.SetVariable("recovered", true)
 		return "recovered", nil
 	})
-	noop := NewActivityFunction("noop", func(ctx Context, params map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, params map[string]any) (any, error) {
 		return nil, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{failIt, recoverIt, noop},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(failIt)
+	reg.MustRegister(recoverIt)
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 }
@@ -1116,7 +1118,7 @@ func TestExecution_Retry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	flakyActivity := NewActivityFunction("flaky", func(ctx Context, params map[string]any) (any, error) {
+	flakyActivity := ActivityFunc("flaky", func(ctx Context, params map[string]any) (any, error) {
 		attempts++
 		if attempts < 3 {
 			return nil, fmt.Errorf("transient error")
@@ -1124,14 +1126,14 @@ func TestExecution_Retry(t *testing.T) {
 		return "ok", nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{flakyActivity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(flakyActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 	require.Equal(t, 3, attempts)
@@ -1158,20 +1160,20 @@ func TestExecution_TemplateParameters(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	printActivity := NewActivityFunction("print", func(ctx Context, params map[string]any) (any, error) {
+	printActivity := ActivityFunc("print", func(ctx Context, params map[string]any) (any, error) {
 		gotMessage = params["message"].(string)
 		return gotMessage, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{printActivity},
-		Inputs:         map[string]any{"name": "World"},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(printActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithInputs(map[string]any{"name": "World"}),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, "Hello World!", gotMessage)
 }
@@ -1197,19 +1199,19 @@ func TestExecution_ScriptExpressionParameters(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	captureActivity := NewActivityFunction("capture", func(ctx Context, params map[string]any) (any, error) {
+	captureActivity := ActivityFunc("capture", func(ctx Context, params map[string]any) (any, error) {
 		gotValue = params["result"]
 		return gotValue, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{captureActivity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(captureActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.EqualValues(t, 50, gotValue)
 }
@@ -1236,7 +1238,7 @@ func TestExecution_EachStep(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	doubleActivity := NewActivityFunction("double", func(ctx Context, params map[string]any) (any, error) {
+	doubleActivity := ActivityFunc("double", func(ctx Context, params map[string]any) (any, error) {
 		// The stub test compiler returns int for integer values, while a
 		// Risor-backed compiler would return int64. Normalize to int64.
 		var v int64
@@ -1253,14 +1255,14 @@ func TestExecution_EachStep(t *testing.T) {
 		return v * 2, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{doubleActivity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(doubleActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 
@@ -1288,10 +1290,10 @@ func TestExecution_EachStep_CleansUpAsVariable(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	echoAct := NewActivityFunction("echo", func(ctx Context, params map[string]any) (any, error) {
+	echoAct := ActivityFunc("echo", func(ctx Context, params map[string]any) (any, error) {
 		return "processed", nil
 	})
-	checkAct := NewActivityFunction("check-leak", func(ctx Context, params map[string]any) (any, error) {
+	checkAct := ActivityFunc("check-leak", func(ctx Context, params map[string]any) (any, error) {
 		// The "item" variable should not exist after the each loop since
 		// it didn't exist before.
 		_, exists := ctx.GetVariable("item")
@@ -1301,14 +1303,15 @@ func TestExecution_EachStep_CleansUpAsVariable(t *testing.T) {
 		return "clean", nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{echoAct, checkAct},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(echoAct)
+	reg.MustRegister(checkAct)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 }
@@ -1336,10 +1339,10 @@ func TestExecution_StoreResult(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	computeActivity := NewActivityFunction("compute", func(ctx Context, params map[string]any) (any, error) {
+	computeActivity := ActivityFunc("compute", func(ctx Context, params map[string]any) (any, error) {
 		return 42, nil
 	})
-	checkActivity := NewActivityFunction("check", func(ctx Context, params map[string]any) (any, error) {
+	checkActivity := ActivityFunc("check", func(ctx Context, params map[string]any) (any, error) {
 		v, ok := ctx.GetVariable("result")
 		if !ok {
 			return nil, fmt.Errorf("result not found in state")
@@ -1350,14 +1353,15 @@ func TestExecution_StoreResult(t *testing.T) {
 		return "verified", nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{computeActivity, checkActivity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(computeActivity)
+	reg.MustRegister(checkActivity)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 	require.Equal(t, 42, exec.GetOutputs()["final"])
@@ -1383,20 +1387,20 @@ func TestExecution_AlreadyStarted(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	a := NewActivityFunction("a", func(ctx Context, params map[string]any) (any, error) {
+	a := ActivityFunc("a", func(ctx Context, params map[string]any) (any, error) {
 		return nil, nil
 	})
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities:     []Activity{a},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(a)
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 
 	// Second run should fail
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.ErrorIs(t, err, ErrAlreadyStarted)
 }

--- a/examples/branching/main.go
+++ b/examples/branching/main.go
@@ -220,20 +220,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:       wf,
-		Inputs:         map[string]any{},
-		ActivityLogger: workflow.NewFileActivityLogger("logs"),
-		Checkpointer:   checkpointer,
-		Activities: []workflow.Activity{
-			workflow.NewTypedActivityFunction("generate_number", generateNumber),
-			workflow.NewTypedActivityFunction("check_prime", checkPrime),
-			workflow.NewTypedActivityFunction("categorize_number", categorizeNumber),
-			workflow.NewTypedActivityFunction("label_prime", labelPrime),
-			workflow.NewTypedActivityFunction("factors_label", factorsLabel),
-			activities.NewPrintActivity(),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.TypedActivityFunc("generate_number", generateNumber))
+	reg.MustRegister(workflow.TypedActivityFunc("check_prime", checkPrime))
+	reg.MustRegister(workflow.TypedActivityFunc("categorize_number", categorizeNumber))
+	reg.MustRegister(workflow.TypedActivityFunc("label_prime", labelPrime))
+	reg.MustRegister(workflow.TypedActivityFunc("factors_label", factorsLabel))
+	reg.MustRegister(activities.NewPrintActivity())
+
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithInputs(map[string]any{}),
+		workflow.WithActivityLogger(workflow.NewFileActivityLogger("logs")),
+		workflow.WithCheckpointer(checkpointer),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -249,7 +248,7 @@ func main() {
 	fmt.Println("5. Different execution branches based on data")
 	fmt.Println()
 
-	if err := execution.Run(ctx); err != nil {
+	if _, err := execution.Execute(ctx); err != nil {
 		log.Fatal(err)
 	}
 	if execution.Status() != workflow.ExecutionStatusCompleted {

--- a/examples/callbacks/main.go
+++ b/examples/callbacks/main.go
@@ -120,15 +120,14 @@ func main() {
 	}
 
 	// Create execution with callbacks
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:           wf,
-		ExecutionCallbacks: callbacks,
-		Activities: []workflow.Activity{
-			activities.NewTimeActivity(),
-			workflow.NewTypedActivityFunction("format_start_message", formatStartMessage),
-			activities.NewPrintActivity(),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(activities.NewTimeActivity())
+	reg.MustRegister(workflow.TypedActivityFunc("format_start_message", formatStartMessage))
+	reg.MustRegister(activities.NewPrintActivity())
+
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithExecutionCallbacks(callbacks),
+	)
 	if err != nil {
 		logger.Error("Failed to create execution", "error", err)
 		os.Exit(1)
@@ -138,7 +137,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := execution.Run(ctx); err != nil {
+	if _, err := execution.Execute(ctx); err != nil {
 		logger.Error("Workflow execution failed", "error", err)
 		os.Exit(1)
 	}

--- a/examples/child_workflows/main.go
+++ b/examples/child_workflows/main.go
@@ -184,12 +184,12 @@ func main() {
 
 	// Create activity list
 	baseActivities := []workflow.Activity{
-		workflow.NewActivityFunction("print", print),
-		workflow.NewActivityFunction("process_data", processData),
-		workflow.NewActivityFunction("validate_data", validateData),
-		workflow.NewTypedActivityFunction("sample_data", sampleData),
-		workflow.NewTypedActivityFunction("extract_processed_result", extractProcessedResult),
-		workflow.NewTypedActivityFunction("extract_validation_result", extractValidationResult),
+		workflow.ActivityFunc("print", print),
+		workflow.ActivityFunc("process_data", processData),
+		workflow.ActivityFunc("validate_data", validateData),
+		workflow.TypedActivityFunc("sample_data", sampleData),
+		workflow.TypedActivityFunc("extract_processed_result", extractProcessedResult),
+		workflow.TypedActivityFunc("extract_validation_result", extractValidationResult),
 	}
 
 	// Create child workflow executor
@@ -295,14 +295,17 @@ func main() {
 	}
 
 	// Create and run parent workflow execution
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:       parentWorkflow,
-		Inputs:         map[string]any{},
-		Activities:     allActivities,
-		Logger:         logger,
-		ActivityLogger: workflow.NewFileActivityLogger("logs"),
-		Checkpointer:   workflow.NewNullCheckpointer(),
-	})
+	reg := workflow.NewActivityRegistry()
+	for _, a := range allActivities {
+		reg.MustRegister(a)
+	}
+
+	execution, err := workflow.NewExecution(parentWorkflow, reg,
+		workflow.WithInputs(map[string]any{}),
+		workflow.WithLogger(logger),
+		workflow.WithActivityLogger(workflow.NewFileActivityLogger("logs")),
+		workflow.WithCheckpointer(workflow.NewNullCheckpointer()),
+	)
 	if err != nil {
 		log.Fatal("Failed to create execution:", err)
 	}
@@ -313,7 +316,7 @@ func main() {
 	fmt.Println("Starting execution...")
 	start := time.Now()
 
-	if err := execution.Run(ctx); err != nil {
+	if _, err := execution.Execute(ctx); err != nil {
 		log.Fatal("Execution failed:", err)
 	}
 

--- a/examples/edge_matching/main.go
+++ b/examples/edge_matching/main.go
@@ -164,17 +164,20 @@ func createFirstStrategyWorkflow() *workflow.Workflow {
 func runWorkflowDemo(w *workflow.Workflow, activities []workflow.Activity) {
 	ctx := context.Background()
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:   w,
-		Inputs:     map[string]any{},
-		Activities: activities,
-	})
+	reg := workflow.NewActivityRegistry()
+	for _, a := range activities {
+		reg.MustRegister(a)
+	}
+
+	execution, err := workflow.NewExecution(w, reg,
+		workflow.WithInputs(map[string]any{}),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create execution: %v", err)
 	}
 
 	// Run the workflow
-	err = execution.Run(ctx)
+	_, err = execution.Execute(ctx)
 	if err != nil {
 		log.Fatalf("Workflow execution failed: %v", err)
 	}

--- a/examples/error_handling/main.go
+++ b/examples/error_handling/main.go
@@ -99,15 +99,14 @@ func main() {
 		log.Fatalf("Failed to create workflow: %v", err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:       wf,
-		ActivityLogger: workflow.NewFileActivityLogger("logs"),
-		Activities: []workflow.Activity{
-			activities.NewPrintActivity(),
-			workflow.NewTypedActivityFunction("unreliable_task", unreliableTask),
-			workflow.NewTypedActivityFunction("error_result", errorResult),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(activities.NewPrintActivity())
+	reg.MustRegister(workflow.TypedActivityFunc("unreliable_task", unreliableTask))
+	reg.MustRegister(workflow.TypedActivityFunc("error_result", errorResult))
+
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithActivityLogger(workflow.NewFileActivityLogger("logs")),
+	)
 	if err != nil {
 		log.Fatalf("Failed to create execution: %v", err)
 	}
@@ -116,7 +115,7 @@ func main() {
 	fmt.Println("Starting error handling demonstration...")
 	fmt.Println()
 
-	err = execution.Run(context.Background())
+	_, err = execution.Execute(context.Background())
 	if err != nil {
 		fmt.Printf("Workflow failed: %v\n", err)
 		os.Exit(1)

--- a/examples/expr/workflow/main.go
+++ b/examples/expr/workflow/main.go
@@ -69,18 +69,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: wf,
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(activities.NewPrintActivity())
+
+	execution, err := workflow.NewExecution(wf, reg,
 		// Use expr as the expression engine for conditions + templates.
-		ScriptCompiler: exprCompiler{},
-		Inputs: map[string]any{
+		workflow.WithScriptCompiler(exprCompiler{}),
+		workflow.WithInputs(map[string]any{
 			"order_total": 120.0,
 			"country":     "CA",
-		},
-		Activities: []workflow.Activity{
-			activities.NewPrintActivity(),
-		},
-	})
+		}),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,7 +87,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := execution.Run(ctx); err != nil {
+	if _, err := execution.Execute(ctx); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println("status:", execution.Status())

--- a/examples/fenced_checkpointer/main.go
+++ b/examples/fenced_checkpointer/main.go
@@ -70,24 +70,23 @@ func main() {
 		lease.check,
 	)
 
-	exec, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:     wf,
-		Checkpointer: fenced,
-		Activities: []workflow.Activity{
-			workflow.NewActivityFunction("do-work",
-				func(ctx workflow.Context, params map[string]any) (any, error) {
-					stepCount++
-					if stepCount == 2 {
-						// Simulate losing the lease mid-execution
-						lease.revoke()
-						fmt.Println("Lease revoked after step 1!")
-					}
-					return "done", nil
-				},
-			),
-			activities.NewPrintActivity(),
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.ActivityFunc("do-work",
+		func(ctx workflow.Context, params map[string]any) (any, error) {
+			stepCount++
+			if stepCount == 2 {
+				// Simulate losing the lease mid-execution
+				lease.revoke()
+				fmt.Println("Lease revoked after step 1!")
+			}
+			return "done", nil
 		},
-	})
+	))
+	reg.MustRegister(activities.NewPrintActivity())
+
+	exec, err := workflow.NewExecution(wf, reg,
+		workflow.WithCheckpointer(fenced),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/join_branches/main.go
+++ b/examples/join_branches/main.go
@@ -67,51 +67,50 @@ func main() {
 	}
 
 	// Create execution with activities
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: wf,
-		Logger:   logger,
-		Activities: []workflow.Activity{
-			workflow.NewActivityFunction("setup_data", func(ctx workflow.Context, params map[string]any) (any, error) {
-				fmt.Println("🚀 Setting up initial data...")
-				return 100, nil
-			}),
-			workflow.NewActivityFunction("work_a", func(ctx workflow.Context, params map[string]any) (any, error) {
-				fmt.Println("⚙️  branch A: Processing...")
-				time.Sleep(100 * time.Millisecond)
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.ActivityFunc("setup_data", func(ctx workflow.Context, params map[string]any) (any, error) {
+		fmt.Println("🚀 Setting up initial data...")
+		return 100, nil
+	}))
+	reg.MustRegister(workflow.ActivityFunc("work_a", func(ctx workflow.Context, params map[string]any) (any, error) {
+		fmt.Println("⚙️  branch A: Processing...")
+		time.Sleep(100 * time.Millisecond)
 
-				initialValue, _ := ctx.GetVariable("initial_value")
-				result := initialValue.(int) * 2
-				fmt.Printf("   branch A result: %d\n", result)
-				return result, nil
-			}),
-			workflow.NewActivityFunction("work_b", func(ctx workflow.Context, params map[string]any) (any, error) {
-				fmt.Println("⚙️  branch B: Processing...")
-				time.Sleep(150 * time.Millisecond)
+		initialValue, _ := ctx.GetVariable("initial_value")
+		result := initialValue.(int) * 2
+		fmt.Printf("   branch A result: %d\n", result)
+		return result, nil
+	}))
+	reg.MustRegister(workflow.ActivityFunc("work_b", func(ctx workflow.Context, params map[string]any) (any, error) {
+		fmt.Println("⚙️  branch B: Processing...")
+		time.Sleep(150 * time.Millisecond)
 
-				initialValue, _ := ctx.GetVariable("initial_value")
-				result := initialValue.(int) * 3
-				fmt.Printf("   branch B result: %d\n", result)
-				return result, nil
-			}),
-			workflow.NewActivityFunction("combine_results", func(ctx workflow.Context, params map[string]any) (any, error) {
-				fmt.Println("🔗 Combining results...")
+		initialValue, _ := ctx.GetVariable("initial_value")
+		result := initialValue.(int) * 3
+		fmt.Printf("   branch B result: %d\n", result)
+		return result, nil
+	}))
+	reg.MustRegister(workflow.ActivityFunc("combine_results", func(ctx workflow.Context, params map[string]any) (any, error) {
+		fmt.Println("🔗 Combining results...")
 
-				// Access the extracted values directly
-				valueA, _ := ctx.GetVariable("valueA")
-				valueB, _ := ctx.GetVariable("valueB")
+		// Access the extracted values directly
+		valueA, _ := ctx.GetVariable("valueA")
+		valueB, _ := ctx.GetVariable("valueB")
 
-				resultA := valueA.(int)
-				resultB := valueB.(int)
+		resultA := valueA.(int)
+		resultB := valueB.(int)
 
-				fmt.Printf("   Value A: %d\n", resultA)
-				fmt.Printf("   Value B: %d\n", resultB)
+		fmt.Printf("   Value A: %d\n", resultA)
+		fmt.Printf("   Value B: %d\n", resultB)
 
-				total := resultA + resultB
-				fmt.Printf("   Combined result: %d\n", total)
-				return total, nil
-			}),
-		},
-	})
+		total := resultA + resultB
+		fmt.Printf("   Combined result: %d\n", total)
+		return total, nil
+	}))
+
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithLogger(logger),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -122,7 +121,7 @@ func main() {
 	defer cancel()
 
 	start := time.Now()
-	err = execution.Run(ctx)
+	_, err = execution.Execute(ctx)
 	duration := time.Since(start)
 
 	if err != nil {

--- a/examples/retry/main.go
+++ b/examples/retry/main.go
@@ -77,16 +77,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:       wf,
-		ActivityLogger: workflow.NewFileActivityLogger("logs"),
-		Checkpointer:   checkpointer,
-		Logger:         logger,
-		Activities: []workflow.Activity{
-			activities.NewPrintActivity(),
-			workflow.NewTypedActivityFunction("unreliable_service", unreliableService),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(activities.NewPrintActivity())
+	reg.MustRegister(workflow.TypedActivityFunc("unreliable_service", unreliableService))
+
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithActivityLogger(workflow.NewFileActivityLogger("logs")),
+		workflow.WithCheckpointer(checkpointer),
+		workflow.WithLogger(logger),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -94,7 +93,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
-	if err := execution.Run(ctx); err != nil {
+	if _, err := execution.Execute(ctx); err != nil {
 		log.Fatal(err)
 	}
 	if execution.Status() != workflow.ExecutionStatusCompleted {

--- a/examples/retry_simple/main.go
+++ b/examples/retry_simple/main.go
@@ -52,19 +52,18 @@ func main() {
 		log.Fatal(err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: w,
-		Logger:   slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		Activities: []workflow.Activity{
-			workflow.NewTypedActivityFunction("my_operation", myOperation),
-			activities.NewPrintActivity(),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.TypedActivityFunc("my_operation", myOperation))
+	reg.MustRegister(activities.NewPrintActivity())
+
+	execution, err := workflow.NewExecution(w, reg,
+		workflow.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := execution.Run(context.Background()); err != nil {
+	if _, err := execution.Execute(context.Background()); err != nil {
 		log.Fatal(err)
 	}
 

--- a/examples/runner/main.go
+++ b/examples/runner/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 
 	// Simulate a data-fetching activity
-	fetchActivity := workflow.NewTypedActivityFunction(
+	fetchActivity := workflow.TypedActivityFunc(
 		"fetch",
 		func(ctx workflow.Context, params map[string]any) (int, error) {
 			time.Sleep(100 * time.Millisecond) // simulate work
@@ -53,13 +53,11 @@ func main() {
 	)
 
 	// Create the execution with standard options
-	exec, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: wf,
-		Activities: []workflow.Activity{
-			fetchActivity,
-			activities.NewPrintActivity(),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(fetchActivity)
+	reg.MustRegister(activities.NewPrintActivity())
+
+	exec, err := workflow.NewExecution(wf, reg)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -67,23 +65,23 @@ func main() {
 	// The Runner adds lifecycle management on top of the execution
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	runner := workflow.NewRunner(workflow.RunnerConfig{
-		Logger:         logger,
-		DefaultTimeout: 30 * time.Second,
-	})
+	runner := workflow.NewRunner(
+		workflow.WithRunnerLogger(logger),
+		workflow.WithDefaultTimeout(30*time.Second),
+	)
 
-	result, err := runner.Run(ctx(), exec, workflow.RunOptions{
+	result, err := runner.Run(ctx(), exec,
 		// Heartbeat proves liveness — useful with distributed workers
-		Heartbeat: &workflow.HeartbeatConfig{
+		workflow.WithHeartbeat(&workflow.HeartbeatConfig{
 			Interval: 5 * time.Second,
 			Func: func(ctx context.Context) error {
 				// In production: renew a distributed lease here
 				return nil
 			},
-		},
+		}),
 
 		// Completion hook produces follow-up workflow descriptors
-		CompletionHook: func(ctx context.Context, result *workflow.ExecutionResult) ([]workflow.FollowUpSpec, error) {
+		workflow.WithCompletionHook(func(ctx context.Context, result *workflow.ExecutionResult) ([]workflow.FollowUpSpec, error) {
 			count, _ := result.Outputs["record_count"].(int)
 			if count > 10 {
 				return []workflow.FollowUpSpec{{
@@ -92,8 +90,8 @@ func main() {
 				}}, nil
 			}
 			return nil, nil
-		},
-	})
+		}),
+	)
 	if err != nil {
 		log.Fatalf("Infrastructure error: %v", err)
 	}

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -88,18 +88,17 @@ func main() {
 		log.Fatal(err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:       wf,
-		ActivityLogger: workflow.NewFileActivityLogger("logs"),
-		Checkpointer:   checkpointer,
-		Inputs:         map[string]any{"max_count": 5},
-		Activities: []workflow.Activity{
-			activities.NewTimeActivity(),
-			activities.NewWaitActivity(),
-			activities.NewPrintActivity(),
-			workflow.NewTypedActivity(incrementActivity{}),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(activities.NewTimeActivity())
+	reg.MustRegister(activities.NewWaitActivity())
+	reg.MustRegister(activities.NewPrintActivity())
+	reg.MustRegister(workflow.NewTypedActivity(incrementActivity{}))
+
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithActivityLogger(workflow.NewFileActivityLogger("logs")),
+		workflow.WithCheckpointer(checkpointer),
+		workflow.WithInputs(map[string]any{"max_count": 5}),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -107,7 +106,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := execution.Run(ctx); err != nil {
+	if _, err := execution.Execute(ctx); err != nil {
 		log.Fatal(err)
 	}
 	if execution.Status() != workflow.ExecutionStatusCompleted {

--- a/examples/step_progress/main.go
+++ b/examples/step_progress/main.go
@@ -71,36 +71,35 @@ func main() {
 
 	store := &logProgressStore{}
 
-	exec, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: wf,
-		Activities: []workflow.Activity{
-			workflow.NewTypedActivityFunction("extract",
-				func(ctx workflow.Context, params map[string]any) (string, error) {
-					time.Sleep(50 * time.Millisecond)
-					return "42 records", nil
-				},
-			),
-			workflow.NewTypedActivityFunction("transform",
-				func(ctx workflow.Context, params map[string]any) (any, error) {
-					// Report intra-activity progress
-					workflow.ReportProgress(ctx, workflow.ProgressDetail{
-						Message: "Transforming batch 1 of 2",
-					})
-					time.Sleep(50 * time.Millisecond)
-
-					workflow.ReportProgress(ctx, workflow.ProgressDetail{
-						Message: "Transforming batch 2 of 2",
-						Data:    map[string]any{"batch": 2, "total": 2},
-					})
-					time.Sleep(50 * time.Millisecond)
-					return nil, nil
-				},
-			),
-			activities.NewPrintActivity(),
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.TypedActivityFunc("extract",
+		func(ctx workflow.Context, params map[string]any) (string, error) {
+			time.Sleep(50 * time.Millisecond)
+			return "42 records", nil
 		},
+	))
+	reg.MustRegister(workflow.TypedActivityFunc("transform",
+		func(ctx workflow.Context, params map[string]any) (any, error) {
+			// Report intra-activity progress
+			workflow.ReportProgress(ctx, workflow.ProgressDetail{
+				Message: "Transforming batch 1 of 2",
+			})
+			time.Sleep(50 * time.Millisecond)
+
+			workflow.ReportProgress(ctx, workflow.ProgressDetail{
+				Message: "Transforming batch 2 of 2",
+				Data:    map[string]any{"batch": 2, "total": 2},
+			})
+			time.Sleep(50 * time.Millisecond)
+			return nil, nil
+		},
+	))
+	reg.MustRegister(activities.NewPrintActivity())
+
+	exec, err := workflow.NewExecution(wf, reg,
 		// Wire up the store — the library handles the rest
-		StepProgressStore: store,
-	})
+		workflow.WithStepProgressStore(store),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/examples/structured_result/main.go
+++ b/examples/structured_result/main.go
@@ -77,14 +77,12 @@ func main() {
 		log.Fatal(err)
 	}
 
-	exec, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: wf,
-		Activities: []workflow.Activity{
-			activities.NewPrintActivity(),
-			workflow.NewTypedActivityFunction("calc_total", calcTotal),
-			workflow.NewTypedActivityFunction("build_summary", buildSummary),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(activities.NewPrintActivity())
+	reg.MustRegister(workflow.TypedActivityFunc("calc_total", calcTotal))
+	reg.MustRegister(workflow.TypedActivityFunc("build_summary", buildSummary))
+
+	exec, err := workflow.NewExecution(wf, reg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/execution.go
+++ b/execution.go
@@ -56,27 +56,92 @@ const (
 	ExecutionStatusFailed    ExecutionStatus = "failed"
 )
 
-// ExecutionOptions configures a new execution
-type ExecutionOptions struct {
-	Workflow           *Workflow
-	Inputs             map[string]any
-	ActivityLogger     ActivityLogger
-	Checkpointer       Checkpointer
-	Logger             *slog.Logger
-	ExecutionID        string
-	Activities         []Activity
-	ScriptCompiler     script.Compiler
-	ExecutionCallbacks ExecutionCallbacks
+// ExecutionOption is a functional option for NewExecution.
+type ExecutionOption func(*executionConfig)
 
-	// StepProgressStore receives step progress updates during execution.
-	// When set, the library automatically tracks step state transitions
-	// and calls UpdateStepProgress on each change. Calls are async —
-	// store latency does not affect execution speed.
-	StepProgressStore StepProgressStore
+// executionConfig collects all optional parameters. It is an internal
+// implementation detail; consumers compose it through With* options.
+type executionConfig struct {
+	inputs              map[string]any
+	activityLogger      ActivityLogger
+	checkpointer        Checkpointer
+	logger              *slog.Logger
+	executionID         string
+	scriptCompiler      script.Compiler
+	executionCallbacks  ExecutionCallbacks
+	stepProgressStore   StepProgressStore
+	signalStore         SignalStore
+}
 
-	// SignalStore is the rendezvous for external signal delivery.
-	// Required to use workflow.Wait inside activities.
-	SignalStore SignalStore
+// WithInputs sets the workflow input values for this execution. Values
+// not present here fall back to the Input.Default declared on the
+// workflow. Extra keys not declared on the workflow are rejected.
+func WithInputs(m map[string]any) ExecutionOption {
+	return func(c *executionConfig) { c.inputs = m }
+}
+
+// WithCheckpointer configures where checkpoint snapshots are saved.
+// Defaults to a null checkpointer that discards everything.
+func WithCheckpointer(cp Checkpointer) ExecutionOption {
+	return func(c *executionConfig) { c.checkpointer = cp }
+}
+
+// WithSignalStore configures the signal delivery rendezvous used by
+// workflow.Wait and declarative WaitSignal steps. Required for any
+// workflow that uses signals.
+func WithSignalStore(ss SignalStore) ExecutionOption {
+	return func(c *executionConfig) { c.signalStore = ss }
+}
+
+// WithLogger sets the structured logger. Defaults to a discard logger.
+func WithLogger(l *slog.Logger) ExecutionOption {
+	return func(c *executionConfig) { c.logger = l }
+}
+
+// WithExecutionID sets a fixed execution ID. When omitted, a new ID is
+// generated via NewExecutionID. Use this when your orchestration layer
+// (queue, DB) needs to know the ID before NewExecution is called.
+func WithExecutionID(id string) ExecutionOption {
+	return func(c *executionConfig) { c.executionID = id }
+}
+
+// WithExecutionCallbacks installs lifecycle callbacks. Defaults to no-op.
+func WithExecutionCallbacks(cb ExecutionCallbacks) ExecutionOption {
+	return func(c *executionConfig) { c.executionCallbacks = cb }
+}
+
+// WithStepProgressStore configures a store that receives progress
+// updates as steps transition between states. Calls are async and
+// store latency does not affect execution speed.
+func WithStepProgressStore(s StepProgressStore) ExecutionOption {
+	return func(c *executionConfig) { c.stepProgressStore = s }
+}
+
+// WithActivityLogger configures where per-activity invocation logs
+// are written. Defaults to a null logger.
+func WithActivityLogger(al ActivityLogger) ExecutionOption {
+	return func(c *executionConfig) { c.activityLogger = al }
+}
+
+// WithScriptCompiler overrides the default script compiler used to
+// evaluate parameter templates and edge conditions. Defaults to the
+// built-in expr compiler.
+func WithScriptCompiler(sc script.Compiler) ExecutionOption {
+	return func(c *executionConfig) { c.scriptCompiler = sc }
+}
+
+// ExecuteOption configures a single call to Execution.Execute.
+type ExecuteOption func(*executeConfig)
+
+type executeConfig struct {
+	priorExecutionID string
+}
+
+// ResumeFrom tells Execute to load the checkpoint for priorID and
+// resume. If no checkpoint is found, Execute proceeds with a fresh
+// run — the semantics of the deleted RunOrResume.
+func ResumeFrom(priorID string) ExecuteOption {
+	return func(c *executeConfig) { c.priorExecutionID = priorID }
 }
 
 // Execution represents a simplified workflow execution with checkpointing
@@ -129,37 +194,44 @@ type Execution struct {
 	checkpointMu sync.Mutex
 }
 
-// NewExecution creates a new simplified execution
-func NewExecution(opts ExecutionOptions) (*Execution, error) {
-	if opts.Workflow == nil {
-		return nil, fmt.Errorf("workflow is required")
+// NewExecution creates a new execution for the given workflow and
+// activity registry. Every configurable knob is a functional option.
+func NewExecution(wf *Workflow, reg *ActivityRegistry, opts ...ExecutionOption) (*Execution, error) {
+	if wf == nil {
+		return nil, fmt.Errorf("workflow: workflow is required")
 	}
-	if len(opts.Activities) == 0 {
-		return nil, fmt.Errorf("activities are required")
-	}
-	if opts.ScriptCompiler == nil {
-		opts.ScriptCompiler = DefaultScriptCompiler()
-	}
-	if opts.Logger == nil {
-		opts.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
-	}
-	if opts.ActivityLogger == nil {
-		opts.ActivityLogger = NewNullActivityLogger()
-	}
-	if opts.Checkpointer == nil {
-		opts.Checkpointer = NewNullCheckpointer()
-	}
-	if opts.ExecutionID == "" {
-		opts.ExecutionID = NewExecutionID()
-	}
-	if opts.ExecutionCallbacks == nil {
-		opts.ExecutionCallbacks = &BaseExecutionCallbacks{}
+	if reg == nil {
+		return nil, fmt.Errorf("workflow: activity registry is required")
 	}
 
-	// Determine input values from inputs map or defaults
-	inputs := make(map[string]any, len(opts.Inputs))
-	for _, input := range opts.Workflow.Inputs() {
-		if v, ok := opts.Inputs[input.Name]; ok {
+	cfg := &executionConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	if cfg.scriptCompiler == nil {
+		cfg.scriptCompiler = DefaultScriptCompiler()
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	if cfg.activityLogger == nil {
+		cfg.activityLogger = NewNullActivityLogger()
+	}
+	if cfg.checkpointer == nil {
+		cfg.checkpointer = NewNullCheckpointer()
+	}
+	if cfg.executionID == "" {
+		cfg.executionID = NewExecutionID()
+	}
+	if cfg.executionCallbacks == nil {
+		cfg.executionCallbacks = &BaseExecutionCallbacks{}
+	}
+
+	// Determine input values from inputs map or defaults.
+	inputs := make(map[string]any, len(cfg.inputs))
+	for _, input := range wf.Inputs() {
+		if v, ok := cfg.inputs[input.Name]; ok {
 			inputs[input.Name] = v
 		} else {
 			if input.Default == nil {
@@ -168,37 +240,33 @@ func NewExecution(opts ExecutionOptions) (*Execution, error) {
 			inputs[input.Name] = input.Default
 		}
 	}
-	for k := range opts.Inputs {
+	for k := range cfg.inputs {
 		if _, ok := inputs[k]; !ok {
 			return nil, fmt.Errorf("unknown input %q", k)
 		}
 	}
 
-	activities := make(map[string]Activity, len(opts.Activities))
-	for _, activity := range opts.Activities {
-		activities[activity.Name()] = activity
-	}
-
-	state := newExecutionState(opts.ExecutionID, opts.Workflow.Name(), inputs)
+	activities := reg.asMap()
+	state := newExecutionState(cfg.executionID, wf.Name(), inputs)
 
 	execution := &Execution{
-		workflow:           opts.Workflow,
+		workflow:           wf,
 		state:              state,
-		activityLogger:     opts.ActivityLogger,
-		checkpointer:       opts.Checkpointer,
-		activeBranches:        map[string]*branch{},
-		branchSnapshots:      make(chan branchSnapshot, 100),
+		activityLogger:     cfg.activityLogger,
+		checkpointer:       cfg.checkpointer,
+		activeBranches:     map[string]*branch{},
+		branchSnapshots:    make(chan branchSnapshot, 100),
 		activities:         activities,
-		logger:             opts.Logger.With("execution_id", opts.ExecutionID),
-		compiler:           opts.ScriptCompiler,
-		executionCallbacks: opts.ExecutionCallbacks,
-		signalStore:        opts.SignalStore,
+		logger:             cfg.logger.With("execution_id", cfg.executionID),
+		compiler:           cfg.scriptCompiler,
+		executionCallbacks: cfg.executionCallbacks,
+		signalStore:        cfg.signalStore,
 	}
 	execution.adapter = &executionAdapter{execution: execution}
 
-	// Wire step progress tracker if a store is configured
-	if opts.StepProgressStore != nil {
-		tracker := newStepProgressTracker(opts.ExecutionID, opts.StepProgressStore, execution.logger)
+	// Wire step progress tracker if a store is configured.
+	if cfg.stepProgressStore != nil {
+		tracker := newStepProgressTracker(cfg.executionID, cfg.stepProgressStore, execution.logger)
 		execution.stepProgressTracker = tracker
 		chain := NewCallbackChain(execution.executionCallbacks, tracker)
 		execution.executionCallbacks = chain
@@ -208,15 +276,15 @@ func NewExecution(opts ExecutionOptions) (*Execution, error) {
 	// createBranch* from e.state.ID() so that a resumed execution whose ID
 	// was restored from a checkpoint sees the right value.
 	execution.branchOptions = branchOptions{
-		Workflow:         opts.Workflow,
+		Workflow:         wf,
 		ActivityRegistry: activities,
-		Logger:           opts.Logger,
+		Logger:           cfg.logger,
 		Inputs:           copyMap(inputs),
-		Variables:        copyMap(opts.Workflow.InitialState()),
+		Variables:        copyMap(wf.InitialState()),
 		activityExecutor: execution.adapter,
 		UpdatesChannel:   execution.branchSnapshots,
-		ScriptCompiler:   opts.ScriptCompiler,
-		SignalStore:      opts.SignalStore,
+		ScriptCompiler:   cfg.scriptCompiler,
+		SignalStore:      cfg.signalStore,
 	}
 
 	return execution, nil
@@ -389,26 +457,60 @@ func (e *Execution) start() error {
 	return nil
 }
 
-// Run the execution to completion.
-func (e *Execution) Run(ctx context.Context) error {
+// Execute runs the workflow and returns a structured ExecutionResult.
+//
+// By default, Execute starts a fresh run. Pass ResumeFrom(priorID) to
+// resume from a previous execution's checkpoint. If ResumeFrom is set
+// and no checkpoint exists for priorID, Execute proceeds with a fresh
+// run.
+//
+// An error return means the execution could not be attempted
+// (infrastructure failure). When error is nil, result is non-nil and
+// contains the execution outcome — including workflow-level failures,
+// which are represented in result.Error rather than the error return.
+func (e *Execution) Execute(ctx context.Context, opts ...ExecuteOption) (*ExecutionResult, error) {
+	cfg := &executeConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	err := e.runExecution(ctx, cfg.priorExecutionID)
+	return e.buildResult(err)
+}
+
+// runExecution is the internal run-or-resume implementation.
+func (e *Execution) runExecution(ctx context.Context, priorExecutionID string) error {
 	e.ran = false
+
+	if priorExecutionID != "" {
+		err := e.resumeFromCheckpoint(ctx, priorExecutionID)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, ErrNoCheckpoint) {
+			return err
+		}
+		// No checkpoint found — fall through to a fresh run.
+	}
+
 	if err := e.start(); err != nil {
 		return err
 	}
 	return e.run(ctx)
 }
 
-// Resume a previous execution from its last checkpoint.
-func (e *Execution) Resume(ctx context.Context, priorExecutionID string) error {
-	e.ran = false
+// resumeFromCheckpoint loads the prior checkpoint, marks the execution
+// as started, and runs it to completion. Returns ErrNoCheckpoint if no
+// checkpoint exists for priorExecutionID.
+func (e *Execution) resumeFromCheckpoint(ctx context.Context, priorExecutionID string) error {
 	// Load checkpoint FIRST, before marking as started.
-	// This way a failed Resume (e.g., no checkpoint) leaves the execution
-	// object clean for a subsequent Run().
+	// This way a failed load (e.g., no checkpoint) leaves the execution
+	// object clean for a subsequent fresh run.
 	if err := e.loadCheckpoint(ctx, priorExecutionID); err != nil {
 		return err
 	}
 
-	// Return early if already completed
+	// Return early if already completed.
 	if e.state.GetStatus() == ExecutionStatusCompleted {
 		e.logger.Info("execution already completed from checkpoint")
 		e.mutex.Lock()
@@ -417,30 +519,10 @@ func (e *Execution) Resume(ctx context.Context, priorExecutionID string) error {
 		return nil
 	}
 
-	// Now mark as started
 	if err := e.start(); err != nil {
 		return err
 	}
-
-	// Continue with normal execution flow
 	return e.run(ctx)
-}
-
-// Execute runs the workflow and returns a structured result.
-//
-// An error return means the execution could not be attempted (infrastructure
-// failure). When error is nil, result is non-nil and contains the execution
-// outcome — including failures, which are represented in result.Error rather
-// than the error return.
-func (e *Execution) Execute(ctx context.Context) (*ExecutionResult, error) {
-	err := e.Run(ctx)
-	return e.buildResult(err)
-}
-
-// ExecuteOrResume is the structured-result equivalent of RunOrResume.
-func (e *Execution) ExecuteOrResume(ctx context.Context, priorExecutionID string) (*ExecutionResult, error) {
-	err := e.RunOrResume(ctx, priorExecutionID)
-	return e.buildResult(err)
 }
 
 func (e *Execution) buildResult(runErr error) (*ExecutionResult, error) {
@@ -551,20 +633,6 @@ func (e *Execution) buildSuspensionInfo() *SuspensionInfo {
 		info.Topics = append(info.Topics, t)
 	}
 	return info
-}
-
-// RunOrResume attempts to resume from a prior execution's checkpoint. If no
-// checkpoint exists, it starts a fresh run. This is the recommended entry point
-// for workers with crash recovery.
-//
-// If a checkpoint exists but is corrupted or cannot be loaded, RunOrResume
-// returns the error rather than silently falling back to a fresh run.
-func (e *Execution) RunOrResume(ctx context.Context, priorExecutionID string) error {
-	err := e.Resume(ctx, priorExecutionID)
-	if errors.Is(err, ErrNoCheckpoint) {
-		return e.Run(ctx)
-	}
-	return err
 }
 
 // run the workflow execution, blocking until completion or error

--- a/execution_callbacks_test.go
+++ b/execution_callbacks_test.go
@@ -97,29 +97,27 @@ func TestExecutionCallbacks(t *testing.T) {
 	callbacks := &TestCallbacksImplementation{events: []string{}}
 
 	// Create execution with callbacks
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		ScriptCompiler:     workflow.NewTestCompiler(),
-		Workflow:           wf,
-		Logger:             logger,
-		ExecutionCallbacks: callbacks,
-		Activities: []workflow.Activity{
-			workflow.NewActivityFunction("time.now", func(ctx workflow.Context, params map[string]any) (any, error) {
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.ActivityFunc("time.now", func(ctx workflow.Context, params map[string]any) (any, error) {
 				return "2025-01-01T12:00:00Z", nil
-			}),
-			workflow.NewActivityFunction("print", func(ctx workflow.Context, params map[string]any) (any, error) {
+			}))
+	reg.MustRegister(workflow.ActivityFunc("print", func(ctx workflow.Context, params map[string]any) (any, error) {
 				message := params["message"].(string)
 				fmt.Printf("Printed: %s\n", message)
 				return nil, nil
-			}),
-		},
-	})
+			}))
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithScriptCompiler(workflow.NewTestCompiler()),
+		workflow.WithLogger(logger),
+		workflow.WithExecutionCallbacks(callbacks),
+	)
 	require.NoError(t, err)
 
 	// Run execution
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	err = execution.Run(ctx)
+	_, err = execution.Execute(ctx)
 	require.NoError(t, err)
 	require.Equal(t, workflow.ExecutionStatusCompleted, execution.Status())
 
@@ -170,25 +168,24 @@ func TestExecutionCallbacksWithFailure(t *testing.T) {
 	callbacks := &TestCallbacksImplementation{events: []string{}}
 
 	// Create execution with callbacks
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		ScriptCompiler:     workflow.NewTestCompiler(),
-		Workflow:           wf,
-		Logger:             logger,
-		ExecutionCallbacks: callbacks,
-		Activities: []workflow.Activity{
-			workflow.NewActivityFunction("fail", func(ctx workflow.Context, params map[string]any) (any, error) {
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.ActivityFunc("fail", func(ctx workflow.Context, params map[string]any) (any, error) {
 				return nil, errors.New("intentional failure")
-			}),
-		},
-	})
+			}))
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithScriptCompiler(workflow.NewTestCompiler()),
+		workflow.WithLogger(logger),
+		workflow.WithExecutionCallbacks(callbacks),
+	)
 	require.NoError(t, err)
 
 	// Run execution (should fail)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	err = execution.Run(ctx)
-	require.Error(t, err)
+	result, err := execution.Execute(ctx)
+	require.NoError(t, err)
+	require.True(t, result.Failed())
 	require.Equal(t, workflow.ExecutionStatusFailed, execution.Status())
 
 	// Verify failure callbacks were called
@@ -245,24 +242,22 @@ func TestCallbackChain(t *testing.T) {
 	callbackChain := workflow.NewCallbackChain(callbacks1, callbacks2)
 
 	// Create execution with callback chain
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		ScriptCompiler:     workflow.NewTestCompiler(),
-		Workflow:           wf,
-		Logger:             logger,
-		ExecutionCallbacks: callbackChain,
-		Activities: []workflow.Activity{
-			workflow.NewActivityFunction("simple", func(ctx workflow.Context, params map[string]any) (any, error) {
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.ActivityFunc("simple", func(ctx workflow.Context, params map[string]any) (any, error) {
 				return "done", nil
-			}),
-		},
-	})
+			}))
+	execution, err := workflow.NewExecution(wf, reg,
+		workflow.WithScriptCompiler(workflow.NewTestCompiler()),
+		workflow.WithLogger(logger),
+		workflow.WithExecutionCallbacks(callbackChain),
+	)
 	require.NoError(t, err)
 
 	// Run execution
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	err = execution.Run(ctx)
+	_, err = execution.Execute(ctx)
 	require.NoError(t, err)
 
 	// Verify both callback implementations were called

--- a/execution_result_test.go
+++ b/execution_result_test.go
@@ -19,15 +19,13 @@ func TestExecuteSuccessReturnsStructuredResult(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("do_work", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("do_work", func(ctx Context, params map[string]any) (any, error) {
 				return "hello", nil
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
 	result, err := exec.Execute(context.Background())
@@ -52,15 +50,13 @@ func TestExecuteFailureReturnsResultNotError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("fail", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("fail", func(ctx Context, params map[string]any) (any, error) {
 				return nil, errors.New("something broke")
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
 	result, err := exec.Execute(context.Background())
@@ -82,15 +78,13 @@ func TestExecuteCalledTwiceReturnsError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("do_work", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("do_work", func(ctx Context, params map[string]any) (any, error) {
 				return "hello", nil
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
 	// First call succeeds
@@ -111,16 +105,14 @@ func TestExecuteInterruptedHasValidDuration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("block", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("block", func(ctx Context, params map[string]any) (any, error) {
 				<-ctx.Done()
 				return nil, ctx.Err()
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -146,19 +138,17 @@ func TestExecuteOrResumeNoCheckpointRunsFresh(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Checkpointer:   NewNullCheckpointer(),
-		Activities: []Activity{
-			NewActivityFunction("do_work", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("do_work", func(ctx Context, params map[string]any) (any, error) {
 				return 42, nil
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithCheckpointer(NewNullCheckpointer()),
+	)
 	require.NoError(t, err)
 
-	result, err := exec.ExecuteOrResume(context.Background(), "nonexistent-id")
+	result, err := exec.Execute(context.Background(), ResumeFrom("nonexistent-id"))
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.Completed())

--- a/execution_test.go
+++ b/execution_test.go
@@ -35,28 +35,27 @@ func TestNewExecutionID(t *testing.T) {
 
 func TestNewExecutionValidation(t *testing.T) {
 	t.Run("missing workflow returns error", func(t *testing.T) {
-		_, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					return nil, nil
-				}),
-			},
-		})
+				}))
+		_, err := NewExecution(nil, reg,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "workflow is required")
 	})
 
-	t.Run("empty activities slice returns error", func(t *testing.T) {
+	t.Run("nil activity registry returns error", func(t *testing.T) {
 		wf, err := New(Options{
 			Name:  "test-workflow",
 			Steps: []*Step{{Name: "start", Activity: "test"}},
 		})
 		require.NoError(t, err)
 
-		_, err = NewExecution(ExecutionOptions{Workflow: wf})
+		_, err = NewExecution(wf, nil)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "activities are required")
+		require.Contains(t, err.Error(), "activity registry is required")
 	})
 
 	t.Run("unknown input is rejected", func(t *testing.T) {
@@ -67,15 +66,14 @@ func TestNewExecutionValidation(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Inputs: map[string]any{
+		reg3 := NewActivityRegistry()
+		_, err = NewExecution(wf, reg3,
+			WithScriptCompiler(newTestCompiler()),
+			WithInputs(map[string]any{
 				"valid_input":   "good",
 				"unknown_input": "bad", // unknown input
-			},
-			Activities: []Activity{nil},
-		})
+			}),
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unknown input")
 	})
@@ -92,16 +90,11 @@ func TestNewExecutionValidation(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Inputs:         map[string]any{}, // missing required input
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
-					return nil, nil
-				}),
-			},
-		})
+		reg4 := NewActivityRegistry()
+		_, err = NewExecution(wf, reg4,
+			WithScriptCompiler(newTestCompiler()),
+			WithInputs(map[string]any{}),
+		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "required_input")
 		require.Contains(t, err.Error(), "is required")
@@ -119,18 +112,16 @@ func TestNewExecutionValidation(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Inputs: map[string]any{
-				"optional_input": "provided_value",
-			},
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg5 := NewActivityRegistry()
+		reg5.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					return nil, nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg5,
+			WithScriptCompiler(newTestCompiler()),
+			WithInputs(map[string]any{
+				"optional_input": "provided_value",
+			}),
+		)
 		require.NoError(t, err)
 		require.NotNil(t, execution)
 		require.NotEmpty(t, execution.ID())
@@ -164,31 +155,31 @@ func TestWorkflowLibraryExample(t *testing.T) {
 
 	gotMessage := ""
 
-	execution, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Inputs:         map[string]any{},
-		Logger:         logger,
-		Activities: []Activity{
-			NewActivityFunction("time.now", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("time.now", func(ctx Context, params map[string]any) (any, error) {
 				return "2025-07-21T12:00:00Z", nil
-			}),
-			NewActivityFunction("print", func(ctx Context, params map[string]any) (any, error) {
+			}))
+	reg.MustRegister(ActivityFunc("print", func(ctx Context, params map[string]any) (any, error) {
 				message, ok := params["message"]
 				if !ok {
 					return nil, errors.New("print activity requires 'message' parameter")
 				}
 				gotMessage = message.(string)
 				return nil, nil
-			}),
-		},
-	})
+			}))
+	execution, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithInputs(map[string]any{}),
+		WithLogger(logger),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	require.NoError(t, execution.Run(ctx))
+	_, err = execution.Execute(ctx)
+
+	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, execution.Status())
 	require.Equal(t, "Processing started at 2025-07-21T12:00:00Z", gotMessage)
 }
@@ -217,25 +208,25 @@ func TestWorkflowOutputCapture(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("math", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("math", func(ctx Context, params map[string]any) (any, error) {
 					return 42, nil
-				}),
-				NewActivityFunction("message", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("message", func(ctx Context, params map[string]any) (any, error) {
 					return "workflow completed successfully", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run the workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		require.NoError(t, execution.Run(ctx))
+		_, err = execution.Execute(ctx)
+
+		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
 		// Verify outputs are captured correctly
@@ -257,19 +248,20 @@ func TestWorkflowOutputCapture(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg2 := NewActivityRegistry()
+		reg2.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					return "value", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg2,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
-		err = execution.Run(context.Background())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "workflow output variable \"nonexistent_variable\" not found")
+		result, err := execution.Execute(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, ExecutionStatusFailed, result.Status)
+		require.NotNil(t, result.Error)
+		require.Contains(t, result.Error.Error(), "workflow output variable \"nonexistent_variable\" not found")
 		require.Equal(t, ExecutionStatusFailed, execution.Status())
 	})
 
@@ -286,17 +278,16 @@ func TestWorkflowOutputCapture(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg3 := NewActivityRegistry()
+		reg3.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					return "test result", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg3,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
-		require.NoError(t, execution.Run(context.Background()))
+		_, err = execution.Execute(context.Background())
+		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
 		// Should have empty outputs map
@@ -315,18 +306,18 @@ func TestWorkflowOutputCapture(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("data", func(ctx Context, params map[string]any) (any, error) {
+		reg4 := NewActivityRegistry()
+		reg4.MustRegister(ActivityFunc("data", func(ctx Context, params map[string]any) (any, error) {
 					return "GREAT SUCCESS", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg4,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
-		require.NoError(t, execution.Run(context.Background()))
+		_, err = execution.Execute(context.Background())
+
+		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
 		// Verify output is captured using default variable name
@@ -355,20 +346,19 @@ func TestFileCheckpointerSavesCheckpoints(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create execution with FileCheckpointer
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					return "success", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Run the workflow
-		require.NoError(t, execution.Run(context.Background()))
+		_, err = execution.Execute(context.Background())
+		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
 		// Verify checkpoint files were created
@@ -410,21 +400,22 @@ func TestFileCheckpointerSavesCheckpoints(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create execution with FileCheckpointer
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("fail", func(ctx Context, params map[string]any) (any, error) {
+		reg2 := NewActivityRegistry()
+		reg2.MustRegister(ActivityFunc("fail", func(ctx Context, params map[string]any) (any, error) {
 					return nil, errors.New("intentional test failure")
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg2,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Run the workflow (expect failure)
-		err = execution.Run(context.Background())
-		require.Error(t, err)
+		result, err := execution.Execute(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, ExecutionStatusFailed, result.Status)
+		require.NotNil(t, result.Error)
 		require.Equal(t, ExecutionStatusFailed, execution.Status())
 
 		// Verify checkpoint files were created even for failed execution
@@ -473,28 +464,29 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 
 		// First execution - should fail
-		execution1, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					return "setup complete", nil
-				}),
-				NewActivityFunction("flaky", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("flaky", func(ctx Context, params map[string]any) (any, error) {
 					callCount++
 					if callCount == 1 {
 						return nil, errors.New("flaky failure on first attempt")
 					}
 					return "success on retry", nil
-				}),
-			},
-		})
+				}))
+		execution1, err := NewExecution(wf, reg,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Run first execution (should fail)
-		err = execution1.Run(context.Background())
-		require.Error(t, err)
+		result1, err := execution1.Execute(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result1)
+		require.Equal(t, ExecutionStatusFailed, result1.Status)
+		require.NotNil(t, result1.Error)
 		require.Equal(t, ExecutionStatusFailed, execution1.Status())
 
 		// Verify checkpoint was saved
@@ -504,27 +496,25 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.Equal(t, "failed", checkpoint.Status)
 
 		// Create second execution to resume from the first one's checkpoint
-		execution2, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg2 := NewActivityRegistry()
+		reg2.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					return "setup complete", nil
-				}),
-				NewActivityFunction("flaky", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("flaky", func(ctx Context, params map[string]any) (any, error) {
 					callCount++
 					if callCount == 1 {
 						return nil, errors.New("flaky failure on first attempt")
 					}
 					return "success on retry", nil
-				}),
-			},
-		})
+				}))
+		execution2, err := NewExecution(wf, reg2,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Resume from the failed execution
-		err = execution2.Resume(context.Background(), execution1.ID())
+		_, err = execution2.Execute(context.Background(), ResumeFrom(execution1.ID()))
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution2.Status())
 
@@ -556,20 +546,18 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 
 		// First execution - should succeed
-		execution1, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg3 := NewActivityRegistry()
+		reg3.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					return "success", nil
-				}),
-			},
-		})
+				}))
+		execution1, err := NewExecution(wf, reg3,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Run first execution (should succeed)
-		err = execution1.Run(context.Background())
+		_, err = execution1.Execute(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution1.Status())
 
@@ -580,26 +568,24 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.Equal(t, "completed", checkpoint.Status)
 
 		// Create second execution to resume from completed one
-		execution2, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		reg4 := NewActivityRegistry()
+		reg4.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
 					t.Fatal("test activity should not be called when resuming completed execution")
 					return nil, nil
-				}),
-			},
-		})
+				}))
+		execution2, err := NewExecution(wf, reg4,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Resume from the completed execution (should be no-op)
-		err = execution2.Resume(context.Background(), execution1.ID())
+		_, err = execution2.Execute(context.Background(), ResumeFrom(execution1.ID()))
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution2.Status())
 	})
 
-	t.Run("resume nonexistent execution returns error", func(t *testing.T) {
+	t.Run("resume nonexistent execution falls back to fresh run", func(t *testing.T) {
 		// Create temp directory for checkpoints
 		tempDir := t.TempDir()
 
@@ -617,22 +603,26 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create execution
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("test", func(ctx Context, params map[string]any) (any, error) {
+		callCount := 0
+		reg5 := NewActivityRegistry()
+		reg5.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
+					callCount++
 					return "success", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg5,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
-		// Try to resume from nonexistent execution ID
-		err = execution.Resume(context.Background(), "nonexistent-execution-id")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "no checkpoint found")
+		// Resume from nonexistent execution ID should silently fall back
+		// to a fresh run under the new Execute(ResumeFrom(...)) contract.
+		result, err := execution.Execute(context.Background(), ResumeFrom("nonexistent-execution-id"))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, ExecutionStatusCompleted, result.Status)
+		require.Equal(t, 1, callCount, "fresh run should have executed the activity once")
+		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 	})
 
 	t.Run("resume with retry mechanism works", func(t *testing.T) {
@@ -672,29 +662,30 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 
 		// First execution - should exhaust retries and fail
-		execution1, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg6 := NewActivityRegistry()
+		reg6.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					return "setup complete", nil
-				}),
-				NewActivityFunction("retry-activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg6.MustRegister(ActivityFunc("retry-activity", func(ctx Context, params map[string]any) (any, error) {
 					callCount++
 					// Fail for the first 4 attempts (initial + 2 retries in first execution + 1 attempt in resumed execution)
 					if callCount <= 4 {
 						return nil, errors.New("activity failure - attempt " + fmt.Sprintf("%d", callCount))
 					}
 					return "success after retries", nil
-				}),
-			},
-		})
+				}))
+		execution1, err := NewExecution(wf, reg6,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Run first execution (should fail after exhausting retries)
-		err = execution1.Run(context.Background())
-		require.Error(t, err)
+		result1, err := execution1.Execute(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result1)
+		require.Equal(t, ExecutionStatusFailed, result1.Status)
+		require.NotNil(t, result1.Error)
 		require.Equal(t, ExecutionStatusFailed, execution1.Status())
 
 		// At this point, callCount should be 3 (initial attempt + 2 retries)
@@ -707,28 +698,26 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		require.Equal(t, "failed", checkpoint.Status)
 
 		// Create second execution to resume from the first one's checkpoint
-		execution2, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Checkpointer:   checkpointer,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg7 := NewActivityRegistry()
+		reg7.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					return "setup complete", nil
-				}),
-				NewActivityFunction("retry-activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg7.MustRegister(ActivityFunc("retry-activity", func(ctx Context, params map[string]any) (any, error) {
 					callCount++
 					// Fail for the first 4 attempts, succeed on the 5th
 					if callCount <= 4 {
 						return nil, errors.New("activity failure - attempt " + fmt.Sprintf("%d", callCount))
 					}
 					return "success after retries", nil
-				}),
-			},
-		})
+				}))
+		execution2, err := NewExecution(wf, reg7,
+			WithScriptCompiler(newTestCompiler()),
+			WithCheckpointer(checkpointer),
+		)
 		require.NoError(t, err)
 
 		// Resume from the failed execution - should retry again and succeed
-		err = execution2.Resume(context.Background(), execution1.ID())
+		_, err = execution2.Execute(context.Background(), ResumeFrom(execution1.ID()))
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution2.Status())
 
@@ -784,32 +773,30 @@ func TestBranchBranching(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("setup", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("setup", func(ctx Context, params map[string]any) (any, error) {
 					addExecutedActivity("setup")
 					// Set up state that will cause both branches to be taken
 					return "A", nil // This will only match path_a condition
-				}),
-				NewActivityFunction("activity_a", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("activity_a", func(ctx Context, params map[string]any) (any, error) {
 					addExecutedActivity("activity_a")
 					return "result from branch A", nil
-				}),
-				NewActivityFunction("activity_b", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("activity_b", func(ctx Context, params map[string]any) (any, error) {
 					addExecutedActivity("activity_b")
 					return "result from branch B", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -879,42 +866,40 @@ func TestBranchBranching(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("setup_data", func(ctx Context, params map[string]any) (any, error) {
+		reg2 := NewActivityRegistry()
+		reg2.MustRegister(ActivityFunc("setup_data", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "setup_data")
 					return 7, nil // Should trigger branch_medium
-				}),
-				NewActivityFunction("process_small", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("process_small", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "process_small")
 					ctx.SetVariable("branch_type", "small")
 					return "small processed", nil
-				}),
-				NewActivityFunction("process_medium", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("process_medium", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "process_medium")
 					ctx.SetVariable("branch_type", "medium")
 					return "medium processed", nil
-				}),
-				NewActivityFunction("process_large", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("process_large", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "process_large")
 					ctx.SetVariable("branch_type", "large")
 					return "large processed", nil
-				}),
-				NewActivityFunction("final_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg2.MustRegister(ActivityFunc("final_activity", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "final_activity")
 					return "workflow completed", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg2,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -987,41 +972,39 @@ func TestBranchBranching(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("start_activity", func(ctx Context, params map[string]any) (any, error) {
+		reg3 := NewActivityRegistry()
+		reg3.MustRegister(ActivityFunc("start_activity", func(ctx Context, params map[string]any) (any, error) {
 					recordBranchExecution("start")
 					return "initialized", nil
-				}),
-				NewActivityFunction("work_1", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg3.MustRegister(ActivityFunc("work_1", func(ctx Context, params map[string]any) (any, error) {
 					recordBranchExecution("path_1")
 					// Simulate some work
 					time.Sleep(10 * time.Millisecond)
 					return "work 1 completed", nil
-				}),
-				NewActivityFunction("work_2", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg3.MustRegister(ActivityFunc("work_2", func(ctx Context, params map[string]any) (any, error) {
 					recordBranchExecution("path_2")
 					// Simulate some work
 					time.Sleep(15 * time.Millisecond)
 					return "work 2 completed", nil
-				}),
-				NewActivityFunction("work_3", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg3.MustRegister(ActivityFunc("work_3", func(ctx Context, params map[string]any) (any, error) {
 					recordBranchExecution("path_3")
 					// Simulate some work
 					time.Sleep(5 * time.Millisecond)
 					return "work 3 completed", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg3,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -1070,32 +1053,33 @@ func TestBranchBranching(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("setup_activity", func(ctx Context, params map[string]any) (any, error) {
+		reg4 := NewActivityRegistry()
+		reg4.MustRegister(ActivityFunc("setup_activity", func(ctx Context, params map[string]any) (any, error) {
 					recordCompletion("setup")
 					return "setup complete", nil
-				}),
-				NewActivityFunction("success_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg4.MustRegister(ActivityFunc("success_activity", func(ctx Context, params map[string]any) (any, error) {
 					recordCompletion("success_path")
 					return "success result", nil
-				}),
-				NewActivityFunction("failure_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg4.MustRegister(ActivityFunc("failure_activity", func(ctx Context, params map[string]any) (any, error) {
 					recordCompletion("failure_path_attempted")
 					return nil, errors.New("intentional failure in one branch")
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg4,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
-		require.Error(t, err) // Execution should fail due to the failed branch
+		result, err := execution.Execute(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, ExecutionStatusFailed, result.Status) // Execution should fail due to the failed branch
+		require.NotNil(t, result.Error)
 		require.Equal(t, ExecutionStatusFailed, execution.Status())
 
 		// Verify setup ran and both branches were attempted
@@ -1148,15 +1132,12 @@ func TestBranchBranching(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("setup_initial_state", func(ctx Context, params map[string]any) (any, error) {
+		reg5 := NewActivityRegistry()
+		reg5.MustRegister(ActivityFunc("setup_initial_state", func(ctx Context, params map[string]any) (any, error) {
 					// Initialize shared counter
 					return 100, nil
-				}),
-				NewActivityFunction("modify_state_alpha", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg5.MustRegister(ActivityFunc("modify_state_alpha", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we start with the setup value
 					counter, ok := ctx.GetVariable("shared_counter")
 					require.True(t, ok)
@@ -1169,8 +1150,8 @@ func TestBranchBranching(t *testing.T) {
 
 					recordBranchExecution("alpha")
 					return "alpha-200", nil
-				}),
-				NewActivityFunction("modify_state_beta", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg5.MustRegister(ActivityFunc("modify_state_beta", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we start with the setup value (not alpha's modification)
 					counter, ok := ctx.GetVariable("shared_counter")
 					require.True(t, ok)
@@ -1183,8 +1164,8 @@ func TestBranchBranching(t *testing.T) {
 
 					recordBranchExecution("beta")
 					return "beta-300", nil
-				}),
-				NewActivityFunction("modify_state_gamma", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg5.MustRegister(ActivityFunc("modify_state_gamma", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we start with the setup value (not alpha's or beta's modifications)
 					counter, ok := ctx.GetVariable("shared_counter")
 					require.True(t, ok)
@@ -1197,16 +1178,17 @@ func TestBranchBranching(t *testing.T) {
 
 					recordBranchExecution("gamma")
 					return "gamma-400", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg5,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -1252,28 +1234,26 @@ func TestNamedBranches(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("analyze_data", func(ctx Context, params map[string]any) (any, error) {
+		reg := NewActivityRegistry()
+		reg.MustRegister(ActivityFunc("analyze_data", func(ctx Context, params map[string]any) (any, error) {
 					return 150, nil // This will trigger large_processing branch
-				}),
-				NewActivityFunction("heavy_work", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("heavy_work", func(ctx Context, params map[string]any) (any, error) {
 					return "heavy processing completed", nil
-				}),
-				NewActivityFunction("light_work", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg.MustRegister(ActivityFunc("light_work", func(ctx Context, params map[string]any) (any, error) {
 					return "light processing completed", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
 		// Run workflow
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err = execution.Run(ctx)
+		_, err = execution.Execute(ctx)
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -1336,20 +1316,21 @@ func TestNamedBranches(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("simple_activity", func(ctx Context, params map[string]any) (any, error) {
+		reg2 := NewActivityRegistry()
+		reg2.MustRegister(ActivityFunc("simple_activity", func(ctx Context, params map[string]any) (any, error) {
 					return "test result", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg2,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
-		err = execution.Run(context.Background())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "output branch \"non_existent_path\" not found")
+		result, err := execution.Execute(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, ExecutionStatusFailed, result.Status)
+		require.NotNil(t, result.Error)
+		require.Contains(t, result.Error.Error(), "output branch \"non_existent_path\" not found")
 	})
 
 	t.Run("backwards compatibility with unnamed edges", func(t *testing.T) {
@@ -1375,24 +1356,22 @@ func TestNamedBranches(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("start_activity", func(ctx Context, params map[string]any) (any, error) {
+		reg3 := NewActivityRegistry()
+		reg3.MustRegister(ActivityFunc("start_activity", func(ctx Context, params map[string]any) (any, error) {
 					return "A", nil
-				}),
-				NewActivityFunction("activity_a", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg3.MustRegister(ActivityFunc("activity_a", func(ctx Context, params map[string]any) (any, error) {
 					return "result from A", nil
-				}),
-				NewActivityFunction("activity_b", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg3.MustRegister(ActivityFunc("activity_b", func(ctx Context, params map[string]any) (any, error) {
 					return "result from B", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg3,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
-		err = execution.Run(context.Background())
+		_, err = execution.Execute(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -1425,24 +1404,22 @@ func TestNamedBranches(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("start_activity", func(ctx Context, params map[string]any) (any, error) {
+		reg4 := NewActivityRegistry()
+		reg4.MustRegister(ActivityFunc("start_activity", func(ctx Context, params map[string]any) (any, error) {
 					return "test_value", nil
-				}),
-				NewActivityFunction("named_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg4.MustRegister(ActivityFunc("named_activity", func(ctx Context, params map[string]any) (any, error) {
 					return "named result", nil
-				}),
-				NewActivityFunction("unnamed_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg4.MustRegister(ActivityFunc("unnamed_activity", func(ctx Context, params map[string]any) (any, error) {
 					return "unnamed result", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg4,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
-		err = execution.Run(context.Background())
+		_, err = execution.Execute(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 
@@ -1484,21 +1461,18 @@ func TestNamedBranches(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		execution, err := NewExecution(ExecutionOptions{
-			ScriptCompiler: newTestCompiler(),
-			Workflow:       wf,
-			Activities: []Activity{
-				NewActivityFunction("start_activity", func(ctx Context, params map[string]any) (any, error) {
+		reg5 := NewActivityRegistry()
+		reg5.MustRegister(ActivityFunc("start_activity", func(ctx Context, params map[string]any) (any, error) {
 					return "step1_done", nil
-				}),
-				NewActivityFunction("continue_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg5.MustRegister(ActivityFunc("continue_activity", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we can see the previous step's result (proving branch continuity)
 					step1Result, exists := ctx.GetVariable("step1_result")
 					require.True(t, exists)
 					require.Equal(t, "step1_done", step1Result)
 					return "step2_done", nil
-				}),
-				NewActivityFunction("final_activity", func(ctx Context, params map[string]any) (any, error) {
+				}))
+		reg5.MustRegister(ActivityFunc("final_activity", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we can see both previous steps' results
 					step1Result, exists := ctx.GetVariable("step1_result")
 					require.True(t, exists)
@@ -1509,12 +1483,13 @@ func TestNamedBranches(t *testing.T) {
 					require.Equal(t, "step2_done", step2Result)
 
 					return "all_steps_done", nil
-				}),
-			},
-		})
+				}))
+		execution, err := NewExecution(wf, reg5,
+			WithScriptCompiler(newTestCompiler()),
+		)
 		require.NoError(t, err)
 
-		err = execution.Run(context.Background())
+		_, err = execution.Execute(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, ExecutionStatusCompleted, execution.Status())
 

--- a/pause_test.go
+++ b/pause_test.go
@@ -20,7 +20,7 @@ func TestPauseExternalLiveBranch(t *testing.T) {
 	// while it is running. After unpause, the gate releases.
 	gate := make(chan struct{})
 	var invocations int32
-	blocking := NewActivityFunction("blocking", func(ctx Context, p map[string]any) (any, error) {
+	blocking := ActivityFunc("blocking", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		select {
 		case <-gate:
@@ -29,7 +29,7 @@ func TestPauseExternalLiveBranch(t *testing.T) {
 			return nil, ctx.Err()
 		}
 	})
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		return "ok", nil
 	})
 
@@ -50,11 +50,12 @@ func TestPauseExternalLiveBranch(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{blocking, noop},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(blocking)
+	reg.MustRegister(noop)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	executionID := exec1.ID()
 
@@ -108,14 +109,15 @@ func TestPauseExternalLiveBranch(t *testing.T) {
 
 	// A fresh execution that Resumes without unpausing should still
 	// see Status=Paused because the sticky flag re-parks the branch.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{blocking, noop},
-		Checkpointer: cp,
-		ExecutionID:  executionID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(blocking)
+	reg2.MustRegister(noop)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(executionID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, executionID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(executionID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusPaused, res2.Status,
 		"resuming without clearing the pause flag should re-park")
@@ -124,14 +126,15 @@ func TestPauseExternalLiveBranch(t *testing.T) {
 	// should complete.
 	require.NoError(t, UnpauseBranchInCheckpoint(ctx, cp, executionID, "main"))
 
-	exec3, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{blocking, noop},
-		Checkpointer: cp,
-		ExecutionID:  executionID,
-	})
+	reg3 := NewActivityRegistry()
+	reg3.MustRegister(blocking)
+	reg3.MustRegister(noop)
+	exec3, err := NewExecution(wf, reg3,
+		WithCheckpointer(cp),
+		WithExecutionID(executionID),
+	)
 	require.NoError(t, err)
-	res3, err := exec3.ExecuteOrResume(ctx, executionID)
+	res3, err := exec3.Execute(ctx, ResumeFrom(executionID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res3.Status,
 		"resuming after unpause should complete")
@@ -197,11 +200,11 @@ func TestPauseDeclarativeStep(t *testing.T) {
 		beforeInvocations int32
 		afterInvocations  int32
 	)
-	before := NewActivityFunction("before", func(ctx Context, p map[string]any) (any, error) {
+	before := ActivityFunc("before", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&beforeInvocations, 1)
 		return "before-ok", nil
 	})
-	after := NewActivityFunction("after", func(ctx Context, p map[string]any) (any, error) {
+	after := ActivityFunc("after", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&afterInvocations, 1)
 		return "after-ok", nil
 	})
@@ -228,11 +231,12 @@ func TestPauseDeclarativeStep(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{before, after},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(before)
+	reg.MustRegister(after)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -259,14 +263,15 @@ func TestPauseDeclarativeStep(t *testing.T) {
 	// Unpause and resume: after should execute.
 	require.NoError(t, UnpauseBranchInCheckpoint(ctx, cp, execID, "main"))
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{before, after},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(before)
+	reg2.MustRegister(after)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 	require.Equal(t, int32(1), atomic.LoadInt32(&beforeInvocations),
@@ -278,7 +283,7 @@ func TestPauseDeclarativeStep(t *testing.T) {
 // completion. The execution ends Paused because the sibling completed
 // but the paused branch is still parked.
 func TestPauseMultiBranch(t *testing.T) {
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		return "ok", nil
 	})
 
@@ -310,10 +315,9 @@ func TestPauseMultiBranch(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{noop},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -341,7 +345,7 @@ func TestPauseMultiBranch(t *testing.T) {
 // TestPauseBranchNotFound confirms PauseBranch/UnpauseBranch return
 // ErrBranchNotFound for unknown branch IDs.
 func TestPauseBranchNotFound(t *testing.T) {
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		return "ok", nil
 	})
 	wf, err := New(Options{
@@ -350,10 +354,9 @@ func TestPauseBranchNotFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{noop},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	err = exec.PauseBranch("nope", "")
@@ -373,7 +376,7 @@ func TestPauseClearedBeforeBoundary(t *testing.T) {
 	// then waits for a release signal, then completes.
 	started := make(chan struct{})
 	release := make(chan struct{})
-	activity := NewActivityFunction("sync", func(ctx Context, p map[string]any) (any, error) {
+	activity := ActivityFunc("sync", func(ctx Context, p map[string]any) (any, error) {
 		close(started)
 		select {
 		case <-release:
@@ -391,10 +394,9 @@ func TestPauseClearedBeforeBoundary(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{activity},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(activity)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/production_readiness_test.go
+++ b/production_readiness_test.go
@@ -28,7 +28,7 @@ func TestMultiWaitWithRecordOrReplay(t *testing.T) {
 	const topic2 = "second-callback"
 
 	var invocations int32
-	multiWait := NewActivityFunction("multi", func(ctx Context, p map[string]any) (any, error) {
+	multiWait := ActivityFunc("multi", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		history := ActivityHistory(ctx)
 
@@ -61,12 +61,12 @@ func TestMultiWaitWithRecordOrReplay(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{multiWait},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(multiWait)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -83,15 +83,15 @@ func TestMultiWaitWithRecordOrReplay(t *testing.T) {
 	require.NoError(t, signals.Send(ctx, execID, topic1, "alpha"))
 
 	// Run 2: replays activity, wait1 consumes signal1, wait2 unwinds.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{multiWait},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(multiWait)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusSuspended, res2.Status,
 		"should re-suspend on wait2 after consuming signal1")
@@ -101,15 +101,15 @@ func TestMultiWaitWithRecordOrReplay(t *testing.T) {
 	require.NoError(t, signals.Send(ctx, execID, topic2, "beta"))
 
 	// Run 3: full replay; wait1 returns cached "alpha"; wait2 consumes signal2.
-	exec3, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{multiWait},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg3 := NewActivityRegistry()
+	reg3.MustRegister(multiWait)
+	exec3, err := NewExecution(wf, reg3,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res3, err := exec3.ExecuteOrResume(ctx, execID)
+	res3, err := exec3.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res3.Status)
 	require.Equal(t, "alpha|beta", res3.Outputs["result"],
@@ -126,7 +126,7 @@ func TestPauseDuringActiveWait(t *testing.T) {
 	gate := make(chan struct{})
 	var invocations int32
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		// Wait for the test to call PauseBranch, then unwind via Wait.
 		<-gate
@@ -142,12 +142,12 @@ func TestPauseDuringActiveWait(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  NewMemorySignalStore(),
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(NewMemorySignalStore()),
+	)
 	require.NoError(t, err)
 	execID := exec.ID()
 
@@ -202,7 +202,7 @@ func TestPauseFreezesSignalWaitDeadline(t *testing.T) {
 	const topic = "frozen-callback"
 	const timeout = 100 * time.Millisecond
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		return Wait(ctx, topic, timeout)
 	})
 
@@ -218,12 +218,12 @@ func TestPauseFreezesSignalWaitDeadline(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -266,15 +266,15 @@ func TestPauseFreezesSignalWaitDeadline(t *testing.T) {
 	// pause-frozen wait still has time on its budget.
 	require.NoError(t, signals.Send(ctx, execID, topic, "delivered"))
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(awaiter)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status,
 		"signal arriving after pause-thaw should still resolve the wait")
@@ -306,8 +306,8 @@ func TestConcurrentSignalDeliveryStress(t *testing.T) {
 		})
 	}
 
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
-	waiter := NewActivityFunction("waiter", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	waiter := ActivityFunc("waiter", func(ctx Context, p map[string]any) (any, error) {
 		topic := fmt.Sprintf("topic-%s", ctx.GetBranchID())
 		return Wait(ctx, topic, time.Minute)
 	})
@@ -318,12 +318,13 @@ func TestConcurrentSignalDeliveryStress(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop, waiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	reg.MustRegister(waiter)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -351,15 +352,16 @@ func TestConcurrentSignalDeliveryStress(t *testing.T) {
 	wg.Wait()
 
 	// Resume.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop, waiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(noop)
+	reg2.MustRegister(waiter)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 
@@ -450,11 +452,10 @@ func TestSuspendedBranchExposesPauseReason(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{noop},
-	})
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -473,8 +474,8 @@ func TestSuspendedBranchExposesPauseReason(t *testing.T) {
 // payload and the workflow completes when all three signals have
 // been delivered.
 func TestResumeFromCheckpointMultipleSignalWaitsInSameExecution(t *testing.T) {
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		// Topic embeds the branch ID so each branch waits on its own.
 		return Wait(ctx, fmt.Sprintf("t-%s", ctx.GetBranchID()), time.Minute)
 	})
@@ -500,12 +501,13 @@ func TestResumeFromCheckpointMultipleSignalWaitsInSameExecution(t *testing.T) {
 
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop, awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	reg.MustRegister(awaiter)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -521,15 +523,16 @@ func TestResumeFromCheckpointMultipleSignalWaitsInSameExecution(t *testing.T) {
 	// because p1 and p3 are still waiting.
 	require.NoError(t, signals.Send(ctx, execID, "t-p2", "two"))
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop, awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(noop)
+	reg2.MustRegister(awaiter)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusSuspended, res2.Status)
 	// Two branches still suspended (p1, p3).
@@ -539,15 +542,16 @@ func TestResumeFromCheckpointMultipleSignalWaitsInSameExecution(t *testing.T) {
 	require.NoError(t, signals.Send(ctx, execID, "t-p1", "one"))
 	require.NoError(t, signals.Send(ctx, execID, "t-p3", "three"))
 
-	exec3, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop, awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg3 := NewActivityRegistry()
+	reg3.MustRegister(noop)
+	reg3.MustRegister(awaiter)
+	exec3, err := NewExecution(wf, reg3,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res3, err := exec3.ExecuteOrResume(ctx, execID)
+	res3, err := exec3.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res3.Status)
 }
@@ -594,7 +598,7 @@ func TestRecordOrReplayWrappingWaitCachesValueOnSuccess(t *testing.T) {
 	const topic = "single-wait"
 	var fnCalls int32
 
-	wrapped := NewActivityFunction("wrapped", func(ctx Context, p map[string]any) (any, error) {
+	wrapped := ActivityFunc("wrapped", func(ctx Context, p map[string]any) (any, error) {
 		history := ActivityHistory(ctx)
 		return history.RecordOrReplay("wait", func() (any, error) {
 			atomic.AddInt32(&fnCalls, 1)
@@ -614,12 +618,12 @@ func TestRecordOrReplayWrappingWaitCachesValueOnSuccess(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{wrapped},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(wrapped)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -633,15 +637,15 @@ func TestRecordOrReplayWrappingWaitCachesValueOnSuccess(t *testing.T) {
 
 	require.NoError(t, signals.Send(ctx, execID, topic, "ok"))
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{wrapped},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(wrapped)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 	require.Equal(t, "ok", res2.Outputs["result"])

--- a/review_fixes_test.go
+++ b/review_fixes_test.go
@@ -20,7 +20,7 @@ func TestInitialWaitConsumedOnceAcrossMultipleSleeps(t *testing.T) {
 	const firstSleep = 30 * time.Millisecond
 	const secondSleep = 500 * time.Millisecond
 
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 
 	wf, err := New(Options{
 		Name: "two-sleeps",
@@ -33,11 +33,11 @@ func TestInitialWaitConsumedOnceAcrossMultipleSleeps(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -57,14 +57,14 @@ func TestInitialWaitConsumedOnceAcrossMultipleSleeps(t *testing.T) {
 	// expired WakeAt. Without the fix, the branch would incorrectly
 	// advance all the way to the "done" step because the stale
 	// deadline (from nap1) has passed.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(noop)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusSuspended, res2.Status,
 		"second resume should re-suspend on nap2 with a fresh deadline")
@@ -83,7 +83,7 @@ func TestInitialWaitConsumedOnceAcrossMultipleSleeps(t *testing.T) {
 // should fail loudly at runtime rather than silently ignoring the
 // name.
 func TestPauseStepRejectsNamedEdge(t *testing.T) {
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 
 	wf, err := New(Options{
 		Name: "pause-named-edge",
@@ -98,10 +98,9 @@ func TestPauseStepRejectsNamedEdge(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{noop},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -123,7 +122,7 @@ func TestPauseExpiredSleepThawUnsticks(t *testing.T) {
 	const duration = 20 * time.Millisecond
 
 	var afterInvocations int32
-	after := NewActivityFunction("after", func(ctx Context, p map[string]any) (any, error) {
+	after := ActivityFunc("after", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&afterInvocations, 1)
 		return "done", nil
 	})
@@ -138,11 +137,11 @@ func TestPauseExpiredSleepThawUnsticks(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(after)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -180,14 +179,14 @@ func TestPauseExpiredSleepThawUnsticks(t *testing.T) {
 
 	// Resume: sleep wakes immediately, successor runs, execution
 	// completes. Before the fix, this would re-suspend forever.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(after)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 	require.Equal(t, int32(1), atomic.LoadInt32(&afterInvocations))
@@ -205,7 +204,7 @@ func TestPauseBranchConcurrentWithBranching(t *testing.T) {
 
 	// Each fanout child just sleeps briefly so the orchestrator has
 	// work to churn through (branch snapshots, activeBranches mutations).
-	worker := NewActivityFunction("worker", func(ctx Context, p map[string]any) (any, error) {
+	worker := ActivityFunc("worker", func(ctx Context, p map[string]any) (any, error) {
 		time.Sleep(2 * time.Millisecond)
 		return "ok", nil
 	})
@@ -226,10 +225,9 @@ func TestPauseBranchConcurrentWithBranching(t *testing.T) {
 	wf, err := New(Options{Name: "race-stress", Steps: steps})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   wf,
-		Activities: []Activity{worker},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(worker)
+	exec, err := NewExecution(wf, reg)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -277,7 +275,7 @@ func TestFinalStatusForcesFailedOnOrchestratorError(t *testing.T) {
 	// pause triggers a save (fails); the completing branch's processing
 	// also triggers a save (fails). Either way executionErr becomes
 	// non-nil with a non-empty pausedIDs set.
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		return "ok", nil
 	})
 
@@ -294,11 +292,11 @@ func TestFinalStatusForcesFailedOnOrchestratorError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop},
-		Checkpointer: failingCp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg,
+		WithCheckpointer(failingCp),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/run_or_resume_test.go
+++ b/run_or_resume_test.go
@@ -9,31 +9,6 @@ import (
 	"github.com/deepnoodle-ai/workflow/internal/require"
 )
 
-func TestErrNoCheckpointSentinel(t *testing.T) {
-	wf, err := New(Options{
-		Name:  "sentinel-test",
-		Steps: []*Step{{Name: "start", Activity: "noop"}},
-	})
-	require.NoError(t, err)
-
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Checkpointer:   NewNullCheckpointer(), // always returns nil, nil
-		Activities: []Activity{
-			NewActivityFunction("noop", func(ctx Context, params map[string]any) (any, error) {
-				return nil, nil
-			}),
-		},
-	})
-	require.NoError(t, err)
-
-	err = exec.Resume(context.Background(), "does-not-exist")
-	require.Error(t, err)
-	require.True(t, errors.Is(err, ErrNoCheckpoint), "should wrap ErrNoCheckpoint")
-	require.Contains(t, err.Error(), "does-not-exist")
-}
-
 func TestRunOrResumeFallsBackOnMissingCheckpoint(t *testing.T) {
 	callCount := 0
 	wf, err := New(Options{
@@ -42,20 +17,18 @@ func TestRunOrResumeFallsBackOnMissingCheckpoint(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Checkpointer:   NewNullCheckpointer(),
-		Activities: []Activity{
-			NewActivityFunction("counter", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("counter", func(ctx Context, params map[string]any) (any, error) {
 				callCount++
 				return nil, nil
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithCheckpointer(NewNullCheckpointer()),
+	)
 	require.NoError(t, err)
 
-	err = exec.RunOrResume(context.Background(), "no-such-checkpoint")
+	_, err = exec.Execute(context.Background(), ResumeFrom("no-such-checkpoint"))
 	require.NoError(t, err)
 	require.Equal(t, 1, callCount, "activity should have run once via fresh Run")
 	require.Equal(t, ExecutionStatusCompleted, exec.Status())
@@ -73,55 +46,21 @@ func TestRunOrResumePropagatesRealErrors(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Checkpointer:   brokenCheckpointer,
-		Activities: []Activity{
-			NewActivityFunction("noop", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("noop", func(ctx Context, params map[string]any) (any, error) {
 				return nil, nil
-			}),
-		},
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithCheckpointer(brokenCheckpointer),
+	)
 	require.NoError(t, err)
 
-	err = exec.RunOrResume(context.Background(), "some-id")
+	_, err = exec.Execute(context.Background(), ResumeFrom("some-id"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "database connection refused")
 	// Should NOT have fallen back to Run — the error is infrastructure, not "no checkpoint"
 	require.False(t, errors.Is(err, ErrNoCheckpoint))
-}
-
-func TestResumeFailureLeaveExecutionReusable(t *testing.T) {
-	// This tests the bug fix: Resume loads checkpoint BEFORE start(),
-	// so a failed Resume (no checkpoint) doesn't taint the execution.
-	wf, err := New(Options{
-		Name:  "reuse-test",
-		Steps: []*Step{{Name: "work", Activity: "noop"}},
-	})
-	require.NoError(t, err)
-
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Checkpointer:   NewNullCheckpointer(),
-		Activities: []Activity{
-			NewActivityFunction("noop", func(ctx Context, params map[string]any) (any, error) {
-				return nil, nil
-			}),
-		},
-	})
-	require.NoError(t, err)
-
-	// First: Resume fails because there's no checkpoint
-	err = exec.Resume(context.Background(), "nonexistent")
-	require.Error(t, err)
-	require.True(t, errors.Is(err, ErrNoCheckpoint))
-
-	// Second: Run should still work because the execution wasn't tainted
-	err = exec.Run(context.Background())
-	require.NoError(t, err)
-	require.Equal(t, ExecutionStatusCompleted, exec.Status())
 }
 
 // errorCheckpointer is a test helper that always returns an error on Load.

--- a/runner.go
+++ b/runner.go
@@ -7,35 +7,62 @@ import (
 	"time"
 )
 
-// RunnerConfig holds reusable settings for a Runner. These are typically set
-// once at application startup and shared across all executions.
-type RunnerConfig struct {
-	// Logger is the structured logger. Defaults to a discard logger.
-	Logger *slog.Logger
+// RunnerOption is a functional option for NewRunner.
+type RunnerOption func(*runnerConfig)
 
-	// DefaultTimeout is applied to every execution unless overridden in
-	// RunOptions. Zero means no timeout.
-	DefaultTimeout time.Duration
+type runnerConfig struct {
+	logger         *slog.Logger
+	defaultTimeout time.Duration
 }
 
-// RunOptions holds per-execution lifecycle settings that the Runner manages
-// on top of a caller-created Execution.
-type RunOptions struct {
-	// PriorExecutionID triggers resume-or-run behavior. When set, the Runner
-	// attempts to resume from this execution's checkpoint before falling back
-	// to a fresh run. When empty, always starts fresh.
-	PriorExecutionID string
+// WithRunnerLogger sets the Runner's structured logger. Defaults to a
+// discard logger.
+func WithRunnerLogger(l *slog.Logger) RunnerOption {
+	return func(c *runnerConfig) { c.logger = l }
+}
 
-	// Heartbeat configures periodic liveness checks. Optional.
-	Heartbeat *HeartbeatConfig
+// WithDefaultTimeout sets the default per-execution timeout applied
+// unless Run overrides it via WithRunTimeout. Zero means no timeout.
+func WithDefaultTimeout(d time.Duration) RunnerOption {
+	return func(c *runnerConfig) { c.defaultTimeout = d }
+}
 
-	// CompletionHook is called after successful execution to produce follow-up
-	// workflow specs. Optional.
-	CompletionHook CompletionHook
+// RunOption is a functional option for a single Runner.Run call.
+type RunOption func(*runConfig)
 
-	// Timeout overrides RunnerConfig.DefaultTimeout for this execution.
-	// Zero means use the default; negative means no timeout.
-	Timeout time.Duration
+type runConfig struct {
+	priorExecutionID string
+	heartbeat        *HeartbeatConfig
+	completionHook   CompletionHook
+	timeout          time.Duration
+	timeoutSet       bool
+}
+
+// WithResumeFrom triggers resume-or-run behavior. When set, the Runner
+// attempts to resume from this execution's checkpoint before falling
+// back to a fresh run. When empty, always starts fresh.
+func WithResumeFrom(priorExecutionID string) RunOption {
+	return func(c *runConfig) { c.priorExecutionID = priorExecutionID }
+}
+
+// WithHeartbeat installs a heartbeat config for this run. Optional.
+func WithHeartbeat(h *HeartbeatConfig) RunOption {
+	return func(c *runConfig) { c.heartbeat = h }
+}
+
+// WithCompletionHook installs a hook called after successful execution
+// to produce follow-up workflow specs. Optional.
+func WithCompletionHook(h CompletionHook) RunOption {
+	return func(c *runConfig) { c.completionHook = h }
+}
+
+// WithRunTimeout overrides the Runner's default timeout for this run.
+// A negative duration means no timeout.
+func WithRunTimeout(d time.Duration) RunOption {
+	return func(c *runConfig) {
+		c.timeout = d
+		c.timeoutSet = true
+	}
 }
 
 // HeartbeatConfig configures periodic liveness reporting.
@@ -53,25 +80,29 @@ type HeartbeatConfig struct {
 // Return nil to continue. Return an error to abort the execution.
 type HeartbeatFunc func(ctx context.Context) error
 
-// Runner manages the full lifecycle of workflow executions. It composes
-// heartbeating, crash recovery (RunOrResume), structured results, and
+// Runner manages the full lifecycle of workflow executions. It
+// composes heartbeating, crash recovery, structured results, and
 // completion hooks.
 //
-// Create a Runner once at startup and call Run for each workflow execution.
+// Create a Runner once at startup and call Run for each workflow
+// execution.
 type Runner struct {
 	logger         *slog.Logger
 	defaultTimeout time.Duration
 }
 
-// NewRunner creates a Runner with the given configuration.
-func NewRunner(cfg RunnerConfig) *Runner {
-	logger := cfg.Logger
-	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+// NewRunner creates a Runner with the given options.
+func NewRunner(opts ...RunnerOption) *Runner {
+	cfg := &runnerConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
 	return &Runner{
-		logger:         logger,
-		defaultTimeout: cfg.DefaultTimeout,
+		logger:         cfg.logger,
+		defaultTimeout: cfg.defaultTimeout,
 	}
 }
 
@@ -79,27 +110,28 @@ func NewRunner(cfg RunnerConfig) *Runner {
 //
 //  1. Starts a heartbeat goroutine (if configured)
 //  2. Applies a timeout (if configured)
-//  3. Calls ExecuteOrResume or Execute (depending on PriorExecutionID)
+//  3. Calls exec.Execute (with ResumeFrom if WithResumeFrom is set)
 //  4. Stops the heartbeat and collects the result
-//  5. Calls the CompletionHook (if configured and execution succeeded)
+//  5. Calls the completion hook (if configured and execution succeeded)
 //  6. Returns the structured ExecutionResult
 //
-// The caller creates the Execution with their own ExecutionOptions.
-// The Runner manages lifecycle concerns on top of that.
+// The caller creates the Execution with its own options. The Runner
+// manages lifecycle concerns on top of that.
 //
-// The error return indicates infrastructure failures (execution couldn't run).
-// Workflow-level failures are in result.Error.
-func (r *Runner) Run(
-	ctx context.Context,
-	exec *Execution,
-	opts RunOptions,
-) (*ExecutionResult, error) {
+// The error return indicates infrastructure failures (execution
+// couldn't run). Workflow-level failures are in result.Error.
+func (r *Runner) Run(ctx context.Context, exec *Execution, opts ...RunOption) (*ExecutionResult, error) {
 	if exec == nil {
 		return nil, ErrNilExecution
 	}
 
-	// Apply timeout
-	timeout := r.resolveTimeout(opts.Timeout)
+	cfg := &runConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Apply timeout.
+	timeout := r.resolveTimeout(cfg)
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
@@ -111,53 +143,53 @@ func (r *Runner) Run(
 	execCtx, execCancel := context.WithCancel(ctx)
 	defer execCancel()
 
-	// Start heartbeat
-	if opts.Heartbeat != nil {
-		if opts.Heartbeat.Interval <= 0 {
+	// Start heartbeat.
+	if cfg.heartbeat != nil {
+		if cfg.heartbeat.Interval <= 0 {
 			return nil, ErrInvalidHeartbeatInterval
 		}
-		if opts.Heartbeat.Func == nil {
+		if cfg.heartbeat.Func == nil {
 			return nil, ErrNilHeartbeatFunc
 		}
-		stopHeartbeat := r.startHeartbeat(execCtx, execCancel, opts.Heartbeat)
+		stopHeartbeat := r.startHeartbeat(execCtx, execCancel, cfg.heartbeat)
 		defer stopHeartbeat()
 	}
 
-	// Run or resume
-	var result *ExecutionResult
-	var err error
-	if opts.PriorExecutionID != "" {
-		result, err = exec.ExecuteOrResume(execCtx, opts.PriorExecutionID)
-	} else {
-		result, err = exec.Execute(execCtx)
+	// Run (optionally resuming from a prior checkpoint).
+	var execOpts []ExecuteOption
+	if cfg.priorExecutionID != "" {
+		execOpts = append(execOpts, ResumeFrom(cfg.priorExecutionID))
 	}
+	result, err := exec.Execute(execCtx, execOpts...)
 	if err != nil {
 		return nil, err
 	}
 
-	// Completion hook
-	if result.Completed() && opts.CompletionHook != nil {
-		followUps, hookErr := opts.CompletionHook(ctx, result)
+	// Completion hook.
+	if result.Completed() && cfg.completionHook != nil {
+		followUps, hookErr := cfg.completionHook(ctx, result)
+		// Attach follow-ups even when the hook returns an error: a
+		// partial list is still useful for diagnosis and the error is
+		// logged separately.
+		result.FollowUps = followUps
 		if hookErr != nil {
 			r.logger.Error("completion hook failed",
 				"execution_id", exec.ID(),
 				"error", hookErr,
 			)
-		} else {
-			result.FollowUps = followUps
 		}
 	}
 
 	return result, nil
 }
 
-// startHeartbeat launches a goroutine that calls the heartbeat function on
-// the configured interval. Returns a stop function that blocks until the
-// goroutine exits.
+// startHeartbeat launches a goroutine that calls the heartbeat
+// function on the configured interval. Returns a stop function that
+// blocks until the goroutine exits.
 //
 // execCancel is called on heartbeat failure to cancel the execution context.
 func (r *Runner) startHeartbeat(ctx context.Context, execCancel context.CancelFunc, cfg *HeartbeatConfig) func() {
-	// A separate cancel to stop the heartbeat goroutine itself on normal completion
+	// A separate cancel to stop the heartbeat goroutine itself on normal completion.
 	hbCtx, hbCancel := context.WithCancel(ctx)
 
 	done := make(chan struct{})
@@ -185,12 +217,12 @@ func (r *Runner) startHeartbeat(ctx context.Context, execCancel context.CancelFu
 	}
 }
 
-func (r *Runner) resolveTimeout(override time.Duration) time.Duration {
-	if override < 0 {
+func (r *Runner) resolveTimeout(cfg *runConfig) time.Duration {
+	if !cfg.timeoutSet {
+		return r.defaultTimeout
+	}
+	if cfg.timeout < 0 {
 		return 0 // explicit no-timeout
 	}
-	if override > 0 {
-		return override
-	}
-	return r.defaultTimeout
+	return cfg.timeout
 }

--- a/runner_suspension_test.go
+++ b/runner_suspension_test.go
@@ -26,20 +26,20 @@ func TestRunnerSurfacesSuspendedResult(t *testing.T) {
 
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		return Wait(ctx, topic, time.Minute)
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{})
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.Suspended())
@@ -66,17 +66,17 @@ func TestRunnerSurfacesPausedResult(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop},
-		Checkpointer: newSpikeMemoryCheckpointer(),
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg,
+		WithCheckpointer(newSpikeMemoryCheckpointer()),
+	)
 	require.NoError(t, err)
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{})
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec)
 	require.NoError(t, err)
 	require.True(t, result.Paused())
 	require.True(t, result.NeedsResume())
@@ -100,26 +100,26 @@ func TestRunnerDoesNotRunCompletionHookOnSuspension(t *testing.T) {
 	require.NoError(t, err)
 
 	signals := NewMemorySignalStore()
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		return Wait(ctx, topic, time.Minute)
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: newSpikeMemoryCheckpointer(),
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithCheckpointer(newSpikeMemoryCheckpointer()),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	var hookCalls int32
-	runner := NewRunner(RunnerConfig{})
-	_, err = runner.Run(context.Background(), exec, RunOptions{
-		CompletionHook: func(ctx context.Context, r *ExecutionResult) ([]FollowUpSpec, error) {
+	runner := NewRunner()
+	_, err = runner.Run(context.Background(), exec,
+		WithCompletionHook(func(ctx context.Context, r *ExecutionResult) ([]FollowUpSpec, error) {
 			atomic.AddInt32(&hookCalls, 1)
 			return nil, nil
-		},
-	})
+		}),
+	)
 	require.NoError(t, err)
 	require.Equal(t, int32(0), atomic.LoadInt32(&hookCalls),
 		"completion hook must not run when the execution is suspended")
@@ -143,21 +143,21 @@ func TestRunnerResumeAfterSignalCompletes(t *testing.T) {
 
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		return Wait(ctx, topic, time.Minute)
 	})
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
-	runner := NewRunner(RunnerConfig{})
-	res1, err := runner.Run(context.Background(), exec1, RunOptions{})
+	runner := NewRunner()
+	res1, err := runner.Run(context.Background(), exec1)
 	require.NoError(t, err)
 	require.True(t, res1.Suspended())
 
@@ -165,18 +165,18 @@ func TestRunnerResumeAfterSignalCompletes(t *testing.T) {
 	require.NoError(t, signals.Send(context.Background(), execID, topic, "from-consumer"))
 
 	// Second Run with PriorExecutionID → resume.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(awaiter)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
 
-	res2, err := runner.Run(context.Background(), exec2, RunOptions{
-		PriorExecutionID: execID,
-	})
+	res2, err := runner.Run(context.Background(), exec2,
+		WithResumeFrom(execID),
+	)
 	require.NoError(t, err)
 	require.True(t, res2.Completed())
 	require.Equal(t, "from-consumer", res2.Outputs["reply"])

--- a/runner_test.go
+++ b/runner_test.go
@@ -25,13 +25,11 @@ func newSimpleWorkflow(t *testing.T) *Workflow {
 
 func newSimpleExecution(t *testing.T, wf *Workflow, activityFn func(Context, map[string]any) (any, error)) *Execution {
 	t.Helper()
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("do_work", activityFn),
-		},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("do_work", activityFn))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 	return exec
 }
@@ -42,8 +40,8 @@ func TestRunnerBasicRun(t *testing.T) {
 		return "hello", nil
 	})
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{})
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec)
 	require.NoError(t, err)
 	require.True(t, result.Completed())
 	require.Equal(t, "hello", result.Outputs["result"])
@@ -57,10 +55,10 @@ func TestRunnerTimeoutCancelsExecution(t *testing.T) {
 		return nil, ctx.Err()
 	})
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		Timeout: 100 * time.Millisecond,
-	})
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec,
+		WithRunTimeout(100 * time.Millisecond),
+	)
 	// Context cancellation during execution means the execution did start
 	// but was interrupted — should return a result with failed status
 	require.NoError(t, err)
@@ -76,15 +74,15 @@ func TestRunnerHeartbeatFailureCancelsExecution(t *testing.T) {
 		return nil, ctx.Err()
 	})
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		Heartbeat: &HeartbeatConfig{
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec,
+		WithHeartbeat(&HeartbeatConfig{
 			Interval: 50 * time.Millisecond,
 			Func: func(ctx context.Context) error {
 				return fmt.Errorf("lease lost")
 			},
-		},
-	})
+		}),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.True(t, result.Failed())
@@ -97,15 +95,15 @@ func TestRunnerCompletionHookProducesFollowUps(t *testing.T) {
 	})
 
 	hookCalled := false
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		CompletionHook: func(ctx context.Context, r *ExecutionResult) ([]FollowUpSpec, error) {
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec,
+		WithCompletionHook(func(ctx context.Context, r *ExecutionResult) ([]FollowUpSpec, error) {
 			hookCalled = true
 			return []FollowUpSpec{
 				{WorkflowName: "follow-up-wf", Inputs: map[string]any{"source": r.Outputs["result"]}},
 			}, nil
-		},
-	})
+		}),
+	)
 	require.NoError(t, err)
 	require.True(t, hookCalled)
 	require.Len(t, result.FollowUps, 1)
@@ -120,13 +118,13 @@ func TestRunnerCompletionHookNotCalledOnFailure(t *testing.T) {
 	})
 
 	hookCalled := false
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		CompletionHook: func(ctx context.Context, r *ExecutionResult) ([]FollowUpSpec, error) {
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec,
+		WithCompletionHook(func(ctx context.Context, r *ExecutionResult) ([]FollowUpSpec, error) {
 			hookCalled = true
 			return nil, nil
-		},
-	})
+		}),
+	)
 	require.NoError(t, err)
 	require.True(t, result.Failed())
 	require.False(t, hookCalled, "hook should not fire on failure")
@@ -139,17 +137,17 @@ func TestRunnerDefaultTimeoutFromConfig(t *testing.T) {
 		return nil, ctx.Err()
 	})
 
-	runner := NewRunner(RunnerConfig{
-		DefaultTimeout: 100 * time.Millisecond,
-	})
-	result, err := runner.Run(context.Background(), exec, RunOptions{})
+	runner := NewRunner(
+		WithDefaultTimeout(100 * time.Millisecond),
+	)
+	result, err := runner.Run(context.Background(), exec)
 	require.NoError(t, err)
 	require.True(t, result.Failed())
 }
 
 func TestRunnerNilExecutionReturnsError(t *testing.T) {
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), nil, RunOptions{})
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), nil)
 	require.ErrorIs(t, err, ErrNilExecution)
 	require.Nil(t, result)
 }
@@ -160,13 +158,13 @@ func TestRunnerHeartbeatZeroIntervalReturnsError(t *testing.T) {
 		return "ok", nil
 	})
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		Heartbeat: &HeartbeatConfig{
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec,
+		WithHeartbeat(&HeartbeatConfig{
 			Interval: 0,
 			Func:     func(ctx context.Context) error { return nil },
-		},
-	})
+		}),
+	)
 	require.ErrorIs(t, err, ErrInvalidHeartbeatInterval)
 	require.Nil(t, result)
 }
@@ -177,13 +175,13 @@ func TestRunnerHeartbeatNilFuncReturnsError(t *testing.T) {
 		return "ok", nil
 	})
 
-	runner := NewRunner(RunnerConfig{})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		Heartbeat: &HeartbeatConfig{
+	runner := NewRunner()
+	result, err := runner.Run(context.Background(), exec,
+		WithHeartbeat(&HeartbeatConfig{
 			Interval: time.Second,
 			Func:     nil,
-		},
-	})
+		}),
+	)
 	require.ErrorIs(t, err, ErrNilHeartbeatFunc)
 	require.Nil(t, result)
 }
@@ -194,12 +192,12 @@ func TestRunnerNegativeTimeoutDisablesDefault(t *testing.T) {
 		return "fast", nil
 	})
 
-	runner := NewRunner(RunnerConfig{
-		DefaultTimeout: 1 * time.Second, // short so regressions surface quickly
-	})
-	result, err := runner.Run(context.Background(), exec, RunOptions{
-		Timeout: -1, // explicit no-timeout override
-	})
+	runner := NewRunner(
+		WithDefaultTimeout(1 * time.Second),
+	)
+	result, err := runner.Run(context.Background(), exec,
+		WithRunTimeout(-1),
+	)
 	require.NoError(t, err)
 	require.True(t, result.Completed())
 }

--- a/script_compiler_test.go
+++ b/script_compiler_test.go
@@ -98,17 +98,18 @@ func TestDefaultCompilerWiring(t *testing.T) {
 	require.NoError(t, err)
 
 	var captured string
-	echo := NewActivityFunction("echo", func(ctx Context, params map[string]any) (any, error) {
+	echo := ActivityFunc("echo", func(ctx Context, params map[string]any) (any, error) {
 		captured, _ = params["value"].(string)
 		return nil, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:   w,
-		Activities: []Activity{echo},
-		Inputs:     map[string]any{"who": "world"},
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(echo)
+	exec, err := NewExecution(w, reg,
+		WithInputs(map[string]any{"who": "world"}),
+	)
 	require.NoError(t, err)
-	require.NoError(t, exec.Run(context.Background()))
+	_, err = exec.Execute(context.Background())
+	require.NoError(t, err)
 	require.Equal(t, "world", captured)
 }

--- a/sleep_test.go
+++ b/sleep_test.go
@@ -19,7 +19,7 @@ func TestSleepStepSuspendsAndResumes(t *testing.T) {
 	const duration = 50 * time.Millisecond
 
 	var afterInvocations int32
-	after := NewActivityFunction("after", func(ctx Context, p map[string]any) (any, error) {
+	after := ActivityFunc("after", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&afterInvocations, 1)
 		return "done", nil
 	})
@@ -42,11 +42,11 @@ func TestSleepStepSuspendsAndResumes(t *testing.T) {
 	require.NoError(t, wf.Validate())
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(after)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -74,14 +74,14 @@ func TestSleepStepSuspendsAndResumes(t *testing.T) {
 	// the successor step should run.
 	time.Sleep(duration + 20*time.Millisecond)
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(after)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 	require.Equal(t, int32(1), atomic.LoadInt32(&afterInvocations))
@@ -96,7 +96,7 @@ func TestSleepResumeBeforeDeadlineReSuspends(t *testing.T) {
 	// deadline.
 	const duration = 10 * time.Second
 
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 
 	wf, err := New(Options{
 		Name: "sleep-early-resume",
@@ -108,11 +108,11 @@ func TestSleepResumeBeforeDeadlineReSuspends(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -126,14 +126,14 @@ func TestSleepResumeBeforeDeadlineReSuspends(t *testing.T) {
 
 	// Resume promptly (well before WakeAt): should re-suspend at the
 	// same absolute WakeAt.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{noop},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(noop)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusSuspended, res2.Status, "should re-suspend before WakeAt")
 	require.Equal(t, SuspensionReasonSleeping, res2.Suspension.Reason)
@@ -149,7 +149,7 @@ func TestSleepPauseFreezesClock(t *testing.T) {
 	const duration = 200 * time.Millisecond
 
 	var afterInvocations int32
-	after := NewActivityFunction("after", func(ctx Context, p map[string]any) (any, error) {
+	after := ActivityFunc("after", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&afterInvocations, 1)
 		return "done", nil
 	})
@@ -164,11 +164,11 @@ func TestSleepPauseFreezesClock(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(after)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -208,28 +208,28 @@ func TestSleepPauseFreezesClock(t *testing.T) {
 
 	// Resume: the branch should re-suspend on the rebased wait because
 	// the sleep hasn't actually elapsed yet.
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(after)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusSuspended, res2.Status, "should re-suspend on rebased wait")
 	require.Equal(t, int32(0), atomic.LoadInt32(&afterInvocations))
 
 	// Wait past the new deadline then resume to completion.
 	time.Sleep(duration + 50*time.Millisecond)
-	exec3, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg3 := NewActivityRegistry()
+	reg3.MustRegister(after)
+	exec3, err := NewExecution(wf, reg3,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res3, err := exec3.ExecuteOrResume(ctx, execID)
+	res3, err := exec3.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res3.Status)
 	require.Equal(t, int32(1), atomic.LoadInt32(&afterInvocations))
@@ -281,7 +281,7 @@ func TestSleepPastDeadlineImmediateWake(t *testing.T) {
 	const duration = 20 * time.Millisecond
 
 	var afterInvocations int32
-	after := NewActivityFunction("after", func(ctx Context, p map[string]any) (any, error) {
+	after := ActivityFunc("after", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&afterInvocations, 1)
 		return "done", nil
 	})
@@ -296,11 +296,11 @@ func TestSleepPastDeadlineImmediateWake(t *testing.T) {
 	require.NoError(t, err)
 
 	cp := newSpikeMemoryCheckpointer()
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(after)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -313,14 +313,14 @@ func TestSleepPastDeadlineImmediateWake(t *testing.T) {
 	// Sleep well past the deadline.
 	time.Sleep(duration + 100*time.Millisecond)
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{after},
-		Checkpointer: cp,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(after)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
-	res, err := exec2.ExecuteOrResume(ctx, execID)
+	res, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res.Status)
 	require.Equal(t, int32(1), atomic.LoadInt32(&afterInvocations))

--- a/step_progress_test.go
+++ b/step_progress_test.go
@@ -42,19 +42,17 @@ func TestStepProgressTrackingLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("work", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("work", func(ctx Context, params map[string]any) (any, error) {
 				return "done", nil
-			}),
-		},
-		StepProgressStore: store,
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithStepProgressStore(store),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 
 	// Wait for async dispatches to complete
@@ -100,23 +98,21 @@ func TestStepProgressReportProgressDetail(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("slow", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("slow", func(ctx Context, params map[string]any) (any, error) {
 				ReportProgress(ctx, ProgressDetail{
 					Message: "Halfway there",
 					Data:    map[string]any{"pct": 50},
 				})
 				return "done", nil
-			}),
-		},
-		StepProgressStore: store,
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+		WithStepProgressStore(store),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 
 	var detail *ProgressDetail
@@ -141,20 +137,17 @@ func TestReportProgressNoopWithoutStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	exec, err := NewExecution(ExecutionOptions{
-		ScriptCompiler: newTestCompiler(),
-		Workflow:       wf,
-		Activities: []Activity{
-			NewActivityFunction("work", func(ctx Context, params map[string]any) (any, error) {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("work", func(ctx Context, params map[string]any) (any, error) {
 				// Should not panic even without a store
 				ReportProgress(ctx, ProgressDetail{Message: "hello"})
 				return nil, nil
-			}),
-		},
-		// No StepProgressStore set
-	})
+			}))
+	exec, err := NewExecution(wf, reg,
+		WithScriptCompiler(newTestCompiler()),
+	)
 	require.NoError(t, err)
 
-	err = exec.Run(context.Background())
+	_, err = exec.Execute(context.Background())
 	require.NoError(t, err)
 }

--- a/typed_activity_example_test.go
+++ b/typed_activity_example_test.go
@@ -53,7 +53,7 @@ func TestTypedActivitySystem(t *testing.T) {
 	require.Equal(t, 8, mathResult.Sum)
 
 	// Test using TypedActivityFunction
-	multiplyActivity := NewTypedActivityFunction("math.multiply",
+	multiplyActivity := TypedActivityFunc("math.multiply",
 		func(ctx Context, params MathParams) (MathResult, error) {
 			return MathResult{Sum: params.A * params.B}, nil
 		})

--- a/wait_test.go
+++ b/wait_test.go
@@ -37,7 +37,7 @@ func TestWaitSpike(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, params map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		reply, err := Wait(ctx, topic, time.Minute)
 		if err != nil {
@@ -47,12 +47,12 @@ func TestWaitSpike(t *testing.T) {
 	})
 
 	// --- First run: should suspend on Wait ---
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	executionID := exec1.ID()
@@ -91,16 +91,16 @@ func TestWaitSpike(t *testing.T) {
 
 	// --- Second execution: a fresh NewExecution instance (simulating
 	//     process death + restart) resumes into the same ID. ---
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  executionID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(awaiter)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(executionID),
+	)
 	require.NoError(t, err)
 
-	res2, err := exec2.ExecuteOrResume(ctx, executionID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(executionID))
 	require.NoError(t, err)
 	require.NotNil(t, res2)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status,
@@ -134,16 +134,16 @@ func TestWaitSignalAlreadyPresent(t *testing.T) {
 	var invocations int32
 	signals := NewMemorySignalStore()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, params map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		return Wait(ctx, topic, time.Minute)
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:    wf,
-		Activities:  []Activity{awaiter},
-		SignalStore: signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	// Pre-deliver the signal before the workflow starts.
@@ -180,16 +180,16 @@ func TestWaitImperativeTimeoutNoCatch(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, params map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		return Wait(ctx, topic, 10*time.Millisecond)
 	})
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -204,16 +204,16 @@ func TestWaitImperativeTimeoutNoCatch(t *testing.T) {
 	// should observe the expired deadline and return ErrWaitTimeout.
 	time.Sleep(30 * time.Millisecond)
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(awaiter)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
 
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusFailed, res2.Status,
 		"timeout with no catch should fail the execution")
@@ -250,19 +250,20 @@ func TestWaitImperativeTimeoutWithCatch(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, params map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		return Wait(ctx, topic, 10*time.Millisecond)
 	})
-	recoverer := NewActivityFunction("recoverer", func(ctx Context, params map[string]any) (any, error) {
+	recoverer := ActivityFunc("recoverer", func(ctx Context, params map[string]any) (any, error) {
 		return "recovered", nil
 	})
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter, recoverer},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	reg.MustRegister(recoverer)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -275,16 +276,17 @@ func TestWaitImperativeTimeoutWithCatch(t *testing.T) {
 
 	time.Sleep(30 * time.Millisecond)
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{awaiter, recoverer},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(awaiter)
+	reg2.MustRegister(recoverer)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
 
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 	require.Equal(t, "recovered", res2.Outputs["result"])
@@ -304,15 +306,15 @@ func TestWaitCancelDuringWait(t *testing.T) {
 
 	signals := NewMemorySignalStore()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, params map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		return Wait(ctx, "any", time.Minute)
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:    wf,
-		Activities:  []Activity{awaiter},
-		SignalStore: signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -357,12 +359,12 @@ func TestWaitSignalDeclarativeStep(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return nil, nil })},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return nil, nil }))
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -378,16 +380,16 @@ func TestWaitSignalDeclarativeStep(t *testing.T) {
 	// Deliver the signal on the resolved topic and resume.
 	require.NoError(t, signals.Send(ctx, execID, "callback-req-42", map[string]any{"ok": true}))
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return nil, nil })},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return nil, nil }))
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
 
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status)
 	require.Equal(t, map[string]any{"ok": true}, res2.Outputs["reply"])
@@ -423,16 +425,16 @@ func TestWaitSignalDeclarativeOnTimeoutRouting(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 
-	mark := NewActivityFunction("mark_timeout", func(ctx Context, p map[string]any) (any, error) {
+	mark := ActivityFunc("mark_timeout", func(ctx Context, p map[string]any) (any, error) {
 		return "timed-out", nil
 	})
 
-	exec1, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{mark},
-		Checkpointer: cp,
-		SignalStore:  signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(mark)
+	exec1, err := NewExecution(wf, reg,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 	execID := exec1.ID()
 
@@ -445,16 +447,16 @@ func TestWaitSignalDeclarativeOnTimeoutRouting(t *testing.T) {
 
 	time.Sleep(25 * time.Millisecond)
 
-	exec2, err := NewExecution(ExecutionOptions{
-		Workflow:     wf,
-		Activities:   []Activity{mark},
-		Checkpointer: cp,
-		SignalStore:  signals,
-		ExecutionID:  execID,
-	})
+	reg2 := NewActivityRegistry()
+	reg2.MustRegister(mark)
+	exec2, err := NewExecution(wf, reg2,
+		WithCheckpointer(cp),
+		WithSignalStore(signals),
+		WithExecutionID(execID),
+	)
 	require.NoError(t, err)
 
-	res2, err := exec2.ExecuteOrResume(ctx, execID)
+	res2, err := exec2.Execute(ctx, ResumeFrom(execID))
 	require.NoError(t, err)
 	require.Equal(t, ExecutionStatusCompleted, res2.Status,
 		"OnTimeout route should produce a successful terminal status")
@@ -492,16 +494,17 @@ func TestWaitMultiBranch(t *testing.T) {
 
 	signals := NewMemorySignalStore()
 
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		return Wait(ctx, topic, time.Minute)
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:    wf,
-		Activities:  []Activity{noop, awaiter},
-		SignalStore: signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(noop)
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -546,16 +549,16 @@ func TestWaitRetryBypass(t *testing.T) {
 	var invocations int32
 	signals := NewMemorySignalStore()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
 		return Wait(ctx, "no-signal", time.Minute)
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:    wf,
-		Activities:  []Activity{awaiter},
-		SignalStore: signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	exec, err := NewExecution(wf, reg,
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -592,19 +595,20 @@ func TestWaitCatchBypass(t *testing.T) {
 	var handleCalled int32
 	signals := NewMemorySignalStore()
 
-	awaiter := NewActivityFunction("awaiter", func(ctx Context, p map[string]any) (any, error) {
+	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		return Wait(ctx, "nope", time.Minute)
 	})
-	noop := NewActivityFunction("noop", func(ctx Context, p map[string]any) (any, error) {
+	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&handleCalled, 1)
 		return nil, nil
 	})
 
-	exec, err := NewExecution(ExecutionOptions{
-		Workflow:    wf,
-		Activities:  []Activity{awaiter, noop},
-		SignalStore: signals,
-	})
+	reg := NewActivityRegistry()
+	reg.MustRegister(awaiter)
+	reg.MustRegister(noop)
+	exec, err := NewExecution(wf, reg,
+		WithSignalStore(signals),
+	)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/workflowtest/mock.go
+++ b/workflowtest/mock.go
@@ -4,14 +4,14 @@ import "github.com/deepnoodle-ai/workflow"
 
 // MockActivity creates a stub activity that always returns the given result.
 func MockActivity(name string, result any) workflow.Activity {
-	return workflow.NewActivityFunction(name, func(ctx workflow.Context, params map[string]any) (any, error) {
+	return workflow.ActivityFunc(name, func(ctx workflow.Context, params map[string]any) (any, error) {
 		return result, nil
 	})
 }
 
 // MockActivityError creates a stub activity that always returns the given error.
 func MockActivityError(name string, err error) workflow.Activity {
-	return workflow.NewActivityFunction(name, func(ctx workflow.Context, params map[string]any) (any, error) {
+	return workflow.ActivityFunc(name, func(ctx workflow.Context, params map[string]any) (any, error) {
 		return nil, err
 	})
 }

--- a/workflowtest/workflowtest.go
+++ b/workflowtest/workflowtest.go
@@ -54,15 +54,26 @@ func RunWithOptions(
 		checkpointer = NewMemoryCheckpointer()
 	}
 
-	exec, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow:           wf,
-		Activities:         activities,
-		Inputs:             inputs,
-		ExecutionID:        opts.ExecutionID,
-		Checkpointer:       checkpointer,
-		ExecutionCallbacks: opts.Callbacks,
-		StepProgressStore:  opts.StepProgressStore,
-	})
+	reg := workflow.NewActivityRegistry()
+	for _, a := range activities {
+		reg.MustRegister(a)
+	}
+
+	execOpts := []workflow.ExecutionOption{
+		workflow.WithInputs(inputs),
+		workflow.WithCheckpointer(checkpointer),
+	}
+	if opts.ExecutionID != "" {
+		execOpts = append(execOpts, workflow.WithExecutionID(opts.ExecutionID))
+	}
+	if opts.Callbacks != nil {
+		execOpts = append(execOpts, workflow.WithExecutionCallbacks(opts.Callbacks))
+	}
+	if opts.StepProgressStore != nil {
+		execOpts = append(execOpts, workflow.WithStepProgressStore(opts.StepProgressStore))
+	}
+
+	exec, err := workflow.NewExecution(wf, reg, execOpts...)
 	if err != nil {
 		t.Fatalf("workflowtest.Run: creating execution: %v", err)
 	}


### PR DESCRIPTION
## Summary

The biggest reshape in the v1 cleanup (§PR4). Every public entry point into the engine now looks like post-v1 code.

### NewExecution
```go
reg := workflow.NewActivityRegistry()
reg.MustRegister(fetchActivity)
reg.MustRegister(storeActivity)

exec, err := workflow.NewExecution(wf, reg,
    workflow.WithInputs(inputs),
    workflow.WithCheckpointer(cp),
    workflow.WithSignalStore(ss),
)
```

### Single Execute method
```go
result, err := exec.Execute(ctx)
result, err := exec.Execute(ctx, workflow.ResumeFrom(priorID))
```

Deletes `Run`, `Resume`, `RunOrResume`, `ExecuteOrResume`. `ResumeFrom` silently falls back to a fresh run when no checkpoint exists, matching the old `RunOrResume` semantics.

### Runner functional options
```go
runner := workflow.NewRunner(
    workflow.WithRunnerLogger(l),
    workflow.WithDefaultTimeout(5*time.Minute),
)
result, err := runner.Run(ctx, exec,
    workflow.WithHeartbeat(hb),
    workflow.WithCompletionHook(hook),
    workflow.WithResumeFrom(priorID),
)
```

### Activity function renames
- `NewActivityFunction` → `ActivityFunc` (http.HandlerFunc style)
- `NewTypedActivityFunction` → `TypedActivityFunc`
- Internal struct types unexported

### Other
- `ActivityRegistry` is now an opaque struct with `Register` / `MustRegister` / `Get` / `Names`. Duplicate registration returns `ErrDuplicateActivity`.
- Runner's completion hook now attaches `FollowUps` even on hook error (logged separately) — also covers §PR11's completion-hook fix.

Every example, test, and consumer site has been updated.

## Test plan

- [x] \`make test-all\` green
- [x] \`go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)