### PR TITLE
PR5: binding validation in NewExecution

### DIFF
--- a/branch_test.go
+++ b/branch_test.go
@@ -662,7 +662,7 @@ func TestExecuteCatchHandler(t *testing.T) {
 				{
 					ErrorEquals: []string{ErrorTypeTimeout},
 					Next:        "step-a",
-					Store:       "state.last_error",
+					Store:       "last_error",
 				},
 			},
 		}

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -1065,7 +1065,7 @@ func TestExecution_CatchHandler(t *testing.T) {
 				Name:     "risky",
 				Activity: "fail-it",
 				Catch: []*CatchConfig{
-					{ErrorEquals: []string{ErrorTypeAll}, Next: "recover", Store: "state.err_info"},
+					{ErrorEquals: []string{ErrorTypeAll}, Next: "recover", Store: "err_info"},
 				},
 				Next: []*Edge{{Step: "done"}},
 			},
@@ -1226,7 +1226,7 @@ func TestExecution_EachStep(t *testing.T) {
 				Name:     "process",
 				Activity: "double",
 				Each:     &Each{Items: []any{1, 2, 3}, As: "item"},
-				Store:    "state.results",
+				Store:    "results",
 				Parameters: map[string]any{
 					"value": "$(state.item)",
 				},
@@ -1282,7 +1282,7 @@ func TestExecution_EachStep_CleansUpAsVariable(t *testing.T) {
 				Name:     "loop",
 				Activity: "echo",
 				Each:     &Each{Items: []any{"a", "b"}, As: "item"},
-				Store:    "state.results",
+				Store:    "results",
 				Next:     []*Edge{{Step: "check"}},
 			},
 			{Name: "check", Activity: "check-leak"},
@@ -1325,7 +1325,7 @@ func TestExecution_StoreResult(t *testing.T) {
 			{
 				Name:     "compute",
 				Activity: "compute",
-				Store:    "state.result",
+				Store:    "result",
 				Next:     []*Edge{{Step: "check"}},
 			},
 			{

--- a/errors.go
+++ b/errors.go
@@ -65,6 +65,21 @@ var (
 	// ErrDuplicateBranchName is reported when two edges declare the
 	// same branch name.
 	ErrDuplicateBranchName = errors.New("workflow: duplicate branch name")
+	// ErrUnknownActivity is reported when a step references an activity
+	// name that is not registered on the ActivityRegistry passed to
+	// NewExecution. Surfaced as a ValidationProblem on *ValidationError.
+	ErrUnknownActivity = errors.New("workflow: activity not registered")
+	// ErrInvalidTemplate is reported when a parameter template or
+	// WaitSignalConfig.Topic template fails to parse or compile.
+	ErrInvalidTemplate = errors.New("workflow: invalid template")
+	// ErrInvalidExpression is reported when an edge condition or
+	// parameter script expression fails to compile.
+	ErrInvalidExpression = errors.New("workflow: invalid expression")
+	// ErrInvalidStorePath is reported when a Store field
+	// (Step.Store, WaitSignalConfig.Store, CatchConfig.Store,
+	// Output.Variable) is given with a leading "state." prefix. Store
+	// fields must be bare variable names.
+	ErrInvalidStorePath = errors.New("workflow: store field must be a bare variable name")
 )
 
 // Error type constants for classification and matching

--- a/examples/branching/main.go
+++ b/examples/branching/main.go
@@ -92,7 +92,7 @@ func main() {
 					"min": 1,
 					"max": 100,
 				},
-				Store: "state.random_number",
+				Store: "random_number",
 				Next:  []*workflow.Edge{{Step: "Display Number"}},
 			},
 			{
@@ -109,7 +109,7 @@ func main() {
 				Parameters: map[string]any{
 					"number": "$(state.random_number)",
 				},
-				Store: "state.is_prime",
+				Store: "is_prime",
 				Next:  []*workflow.Edge{{Step: "Categorize Number"}},
 			},
 			{
@@ -118,7 +118,7 @@ func main() {
 				Parameters: map[string]any{
 					"number": "$(state.random_number)",
 				},
-				Store: "state.category",
+				Store: "category",
 				// expr treats state.category as a string once assigned.
 				Next: []*workflow.Edge{
 					{Step: "Handle Prime Small", Condition: `state.is_prime == true && state.category == "small"`},
@@ -182,7 +182,7 @@ func main() {
 			{
 				Name:     "Calculate Factors",
 				Activity: "factors_label",
-				Store:    "state.factors",
+				Store:    "factors",
 				Next:     []*workflow.Edge{{Step: "Display Factors"}},
 			},
 			{
@@ -199,7 +199,7 @@ func main() {
 				Parameters: map[string]any{
 					"is_prime": "$(state.is_prime)",
 				},
-				Store: "state.prime_label",
+				Store: "prime_label",
 				Next:  []*workflow.Edge{{Step: "Conclusion"}},
 			},
 			{

--- a/examples/callbacks/main.go
+++ b/examples/callbacks/main.go
@@ -93,7 +93,7 @@ func main() {
 			{
 				Name:     "Get Current Time",
 				Activity: "time",
-				Store:    "state.start_time",
+				Store:    "start_time",
 				Next:     []*workflow.Edge{{Step: "Process Data"}},
 			},
 			{
@@ -102,7 +102,7 @@ func main() {
 				Parameters: map[string]any{
 					"start_time": "${state.start_time}",
 				},
-				Store: "state.message",
+				Store: "message",
 				Next:  []*workflow.Edge{{Step: "Print Result"}},
 			},
 			{

--- a/examples/child_workflows/main.go
+++ b/examples/child_workflows/main.go
@@ -222,7 +222,7 @@ func main() {
 			{
 				Name:     "Set Initial Data",
 				Activity: "sample_data",
-				Store:    "state.raw_data",
+				Store:    "raw_data",
 				Next:     []*workflow.Edge{{Step: "Call Data Processor"}},
 			},
 			{
@@ -245,7 +245,7 @@ func main() {
 				Parameters: map[string]any{
 					"outputs": "$(state.processing_workflow_result.outputs)",
 				},
-				Store: "state.processed_data",
+				Store: "processed_data",
 				Next:  []*workflow.Edge{{Step: "Call Data Validator"}},
 			},
 			{
@@ -268,7 +268,7 @@ func main() {
 				Parameters: map[string]any{
 					"outputs": "$(state.validation_workflow_result.outputs)",
 				},
-				Store: "state.is_valid",
+				Store: "is_valid",
 				Next: []*workflow.Edge{
 					{Step: "Success", Condition: "state.is_valid == true"},
 					{Step: "Failure", Condition: "state.is_valid == false"},

--- a/examples/retry/main.go
+++ b/examples/retry/main.go
@@ -42,7 +42,7 @@ func main() {
 			{
 				Name:     "Call Unreliable Service",
 				Activity: "unreliable_service",
-				Store:    "state.service_data",
+				Store:    "service_data",
 				Retry: []*workflow.RetryConfig{{
 					ErrorEquals: []string{workflow.ErrorTypeTimeout},
 					MaxRetries:  3,

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -41,7 +41,7 @@ func main() {
 			{
 				Name:     "Get Current Time",
 				Activity: "time",
-				Store:    "state.current_time",
+				Store:    "current_time",
 				Next:     []*workflow.Edge{{Step: "Print Current Time"}},
 			},
 			{
@@ -58,7 +58,7 @@ func main() {
 				Parameters: map[string]any{
 					"value": "$(state.counter)",
 				},
-				Store: "state.counter",
+				Store: "counter",
 				Next:  []*workflow.Edge{{Step: "Wait Then Loop"}},
 			},
 			{

--- a/examples/structured_result/main.go
+++ b/examples/structured_result/main.go
@@ -50,7 +50,7 @@ func main() {
 				Parameters: map[string]any{
 					"quantity": "$(inputs.quantity)",
 				},
-				Store: "state.total",
+				Store: "total",
 				Next:  []*workflow.Edge{{Step: "Generate Summary"}},
 			},
 			{
@@ -61,7 +61,7 @@ func main() {
 					"quantity": "$(inputs.quantity)",
 					"total":    "$(state.total)",
 				},
-				Store: "state.summary",
+				Store: "summary",
 				Next:  []*workflow.Edge{{Step: "Print Result"}},
 			},
 			{

--- a/execution.go
+++ b/execution.go
@@ -228,6 +228,13 @@ func NewExecution(wf *Workflow, reg *ActivityRegistry, opts ...ExecutionOption) 
 		cfg.executionCallbacks = &BaseExecutionCallbacks{}
 	}
 
+	// Binding-level validation: activity references, templates,
+	// expressions, and store-path shape. Runs after defaults are
+	// applied so the compiler and logger are always present.
+	if err := wf.validateBinding(reg, cfg.scriptCompiler, cfg.signalStore != nil, cfg.logger); err != nil {
+		return nil, err
+	}
+
 	// Determine input values from inputs map or defaults.
 	inputs := make(map[string]any, len(cfg.inputs))
 	for _, input := range wf.Inputs() {

--- a/execution_test.go
+++ b/execution_test.go
@@ -67,6 +67,9 @@ func TestNewExecutionValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		reg3 := NewActivityRegistry()
+		reg3.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
+			return nil, nil
+		}))
 		_, err = NewExecution(wf, reg3,
 			WithScriptCompiler(newTestCompiler()),
 			WithInputs(map[string]any{
@@ -91,6 +94,9 @@ func TestNewExecutionValidation(t *testing.T) {
 		require.NoError(t, err)
 
 		reg4 := NewActivityRegistry()
+		reg4.MustRegister(ActivityFunc("test", func(ctx Context, params map[string]any) (any, error) {
+			return nil, nil
+		}))
 		_, err = NewExecution(wf, reg4,
 			WithScriptCompiler(newTestCompiler()),
 			WithInputs(map[string]any{}),

--- a/validate.go
+++ b/validate.go
@@ -1,9 +1,13 @@
 package workflow
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
+
+	"github.com/deepnoodle-ai/workflow/script"
 )
 
 // ValidationProblem describes a single structural issue in a workflow.
@@ -253,4 +257,185 @@ func (w *Workflow) branchExists(name string) bool {
 		}
 	}
 	return false
+}
+
+// validateBinding runs binding-level checks that require access to the
+// activity registry and script compiler. These cannot run inside
+// workflow.New because the registry and compiler are bound at
+// NewExecution time.
+//
+// Checks performed:
+//  1. Activity references resolve in the registry.
+//  2. Parameter templates ("${...}") and bare script expressions
+//     ("$(...)") compile against the given compiler.
+//  3. Edge condition expressions compile.
+//  4. WaitSignalConfig.Topic templates compile.
+//  5. Step.Store, WaitSignalConfig.Store, CatchConfig.Store, and
+//     Output.Variable reject any "state." prefix.
+//  6. Warn — do not error — if any step uses WaitSignalConfig and no
+//     SignalStore is configured.
+//
+// All problems are collected into a single *ValidationError.
+func (w *Workflow) validateBinding(reg *ActivityRegistry, compiler script.Compiler, hasSignalStore bool, logger *slog.Logger) error {
+	var problems []ValidationProblem
+	add := func(step, msg string, sentinel error) {
+		problems = append(problems, ValidationProblem{
+			Step:    step,
+			Message: msg,
+			Err:     sentinel,
+		})
+	}
+
+	ctx := context.Background()
+
+	// Helper: compile a parameter value recursively, flagging any
+	// template or $(...) expression that fails to parse.
+	var checkParamValue func(stepName, paramName string, value any)
+	checkParamValue = func(stepName, paramName string, value any) {
+		switch v := value.(type) {
+		case map[string]any:
+			for k, vv := range v {
+				checkParamValue(stepName, paramName+"."+k, vv)
+			}
+		case []any:
+			for i, vv := range v {
+				checkParamValue(stepName, fmt.Sprintf("%s[%d]", paramName, i), vv)
+			}
+		case string:
+			checkParamString(ctx, compiler, stepName, paramName, v, add)
+		}
+	}
+
+	usesWaitSignal := false
+
+	// 1. Activity references.
+	for _, step := range w.steps {
+		if step.Activity == "" {
+			continue
+		}
+		if _, ok := reg.Get(step.Activity); !ok {
+			add(step.Name,
+				fmt.Sprintf("unknown activity %q", step.Activity),
+				ErrUnknownActivity)
+		}
+	}
+
+	// 2. Parameter templates and $(...) expressions.
+	for _, step := range w.steps {
+		for name, value := range step.Parameters {
+			checkParamValue(step.Name, name, value)
+		}
+	}
+
+	// 3. Edge condition expressions.
+	for _, step := range w.steps {
+		for i, edge := range step.Next {
+			if edge.Condition == "" {
+				continue
+			}
+			cond := edge.Condition
+			switch strings.ToLower(strings.TrimSpace(cond)) {
+			case "true", "false":
+				continue
+			}
+			if strings.HasPrefix(cond, "$(") && strings.HasSuffix(cond, ")") {
+				cond = strings.TrimSuffix(strings.TrimPrefix(cond, "$("), ")")
+			}
+			if _, err := compiler.Compile(ctx, cond); err != nil {
+				add(step.Name,
+					fmt.Sprintf("edge[%d] condition %q: %v", i, edge.Condition, err),
+					ErrInvalidExpression)
+			}
+		}
+	}
+
+	// 4. WaitSignalConfig.Topic template compiles.
+	for _, step := range w.steps {
+		ws := step.WaitSignal
+		if ws == nil {
+			continue
+		}
+		usesWaitSignal = true
+		if ws.Topic != "" {
+			topic := ws.Topic
+			if strings.HasPrefix(topic, "$(") && strings.HasSuffix(topic, ")") {
+				topic = strings.TrimSuffix(strings.TrimPrefix(topic, "$("), ")")
+				if _, err := compiler.Compile(ctx, topic); err != nil {
+					add(step.Name,
+						fmt.Sprintf("wait_signal topic %q: %v", ws.Topic, err),
+						ErrInvalidTemplate)
+				}
+			} else if _, err := script.NewTemplate(compiler, topic); err != nil {
+				add(step.Name,
+					fmt.Sprintf("wait_signal topic %q: %v", ws.Topic, err),
+					ErrInvalidTemplate)
+			}
+		}
+	}
+
+	// 5. Store fields reject "state." prefix.
+	for _, step := range w.steps {
+		if hasStatePrefix(step.Store) {
+			add(step.Name,
+				fmt.Sprintf("store %q must be a bare variable name, not a %q path", step.Store, "state."),
+				ErrInvalidStorePath)
+		}
+		if step.WaitSignal != nil && hasStatePrefix(step.WaitSignal.Store) {
+			add(step.Name,
+				fmt.Sprintf("wait_signal store %q must be a bare variable name", step.WaitSignal.Store),
+				ErrInvalidStorePath)
+		}
+		for i, c := range step.Catch {
+			if hasStatePrefix(c.Store) {
+				add(step.Name,
+					fmt.Sprintf("catch[%d] store %q must be a bare variable name", i, c.Store),
+					ErrInvalidStorePath)
+			}
+		}
+	}
+	for _, out := range w.outputs {
+		if hasStatePrefix(out.Variable) {
+			add("",
+				fmt.Sprintf("output %q variable %q must be a bare variable name", out.Name, out.Variable),
+				ErrInvalidStorePath)
+		}
+	}
+
+	// 6. Warn (do not error) if WaitSignal is used without a SignalStore.
+	if usesWaitSignal && !hasSignalStore && logger != nil {
+		logger.Warn("workflow uses wait_signal steps but no SignalStore is configured; signals cannot be delivered",
+			"workflow", w.name)
+	}
+
+	if len(problems) > 0 {
+		return &ValidationError{Problems: problems}
+	}
+	return nil
+}
+
+// hasStatePrefix reports whether s begins with the reserved "state."
+// prefix that Store fields must not carry.
+func hasStatePrefix(s string) bool {
+	return strings.HasPrefix(s, "state.")
+}
+
+// checkParamString compiles a single parameter string value, reporting
+// any parse or compile failure as a ValidationProblem.
+func checkParamString(ctx context.Context, compiler script.Compiler, stepName, paramName, value string, add func(step, msg string, sentinel error)) {
+	if strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")") {
+		code := strings.TrimSuffix(strings.TrimPrefix(value, "$("), ")")
+		if _, err := compiler.Compile(ctx, code); err != nil {
+			add(stepName,
+				fmt.Sprintf("parameter %q: %v", paramName, err),
+				ErrInvalidExpression)
+		}
+		return
+	}
+	if strings.Contains(value, "${") {
+		if _, err := script.NewTemplate(compiler, value); err != nil {
+			add(stepName,
+				fmt.Sprintf("parameter %q: %v", paramName, err),
+				ErrInvalidTemplate)
+		}
+	}
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/deepnoodle-ai/workflow/internal/require"
 )
@@ -168,6 +169,260 @@ func TestValidateRejectsInvalidRetryConfig(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.True(t, errors.Is(err, ErrInvalidRetryConfig))
+}
+
+// --- Phase 2: binding validation ---
+
+func bindingReg() *ActivityRegistry {
+	reg := NewActivityRegistry()
+	reg.MustRegister(ActivityFunc("a", func(ctx Context, params map[string]any) (any, error) {
+		return nil, nil
+	}))
+	reg.MustRegister(ActivityFunc("b", func(ctx Context, params map[string]any) (any, error) {
+		return nil, nil
+	}))
+	return reg
+}
+
+func TestBindingValidation_UnknownActivity(t *testing.T) {
+	wf, err := New(Options{
+		Name: "unknown-activity",
+		Steps: []*Step{
+			{Name: "start", Activity: "missing"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrUnknownActivity))
+}
+
+func TestBindingValidation_BadParameterExpression(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-param",
+		Steps: []*Step{
+			{
+				Name:     "start",
+				Activity: "a",
+				Parameters: map[string]any{
+					"value": "$(!!bogus!!)",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidExpression))
+}
+
+func TestBindingValidation_BadParameterTemplate(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-template",
+		Steps: []*Step{
+			{
+				Name:     "start",
+				Activity: "a",
+				Parameters: map[string]any{
+					"msg": "hello ${!!bogus!!} world",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidTemplate))
+}
+
+func TestBindingValidation_BadEdgeCondition(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-cond",
+		Steps: []*Step{
+			{
+				Name:     "start",
+				Activity: "a",
+				Next: []*Edge{
+					{Step: "end", Condition: "!!bogus!!"},
+				},
+			},
+			{Name: "end", Activity: "b"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidExpression))
+}
+
+func TestBindingValidation_EdgeConditionTrueFalseSkipsCompile(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bool-cond",
+		Steps: []*Step{
+			{
+				Name:     "start",
+				Activity: "a",
+				Next: []*Edge{
+					{Step: "end", Condition: "true"},
+				},
+			},
+			{Name: "end", Activity: "b"},
+		},
+	})
+	require.NoError(t, err)
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.NoError(t, err)
+}
+
+func TestBindingValidation_WaitSignalTopicTemplate(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-topic",
+		Steps: []*Step{
+			{
+				Name: "gate",
+				WaitSignal: &WaitSignalConfig{
+					Topic:   "approved-${!!bogus!!}",
+					Timeout: time.Second,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(),
+		WithScriptCompiler(newTestCompiler()),
+		WithSignalStore(NewMemorySignalStore()),
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidTemplate))
+}
+
+func TestBindingValidation_RejectsStatePrefixOnStepStore(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-store",
+		Steps: []*Step{
+			{Name: "start", Activity: "a", Store: "state.result"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidStorePath))
+}
+
+func TestBindingValidation_RejectsStatePrefixOnCatchStore(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-catch-store",
+		Steps: []*Step{
+			{
+				Name:     "start",
+				Activity: "a",
+				Catch: []*CatchConfig{
+					{ErrorEquals: []string{"all"}, Next: "end", Store: "state.err"},
+				},
+			},
+			{Name: "end", Activity: "b"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidStorePath))
+}
+
+func TestBindingValidation_RejectsStatePrefixOnWaitStore(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-wait-store",
+		Steps: []*Step{
+			{
+				Name: "gate",
+				WaitSignal: &WaitSignalConfig{
+					Topic:   "topic",
+					Timeout: time.Second,
+					Store:   "state.payload",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(),
+		WithScriptCompiler(newTestCompiler()),
+		WithSignalStore(NewMemorySignalStore()),
+	)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidStorePath))
+}
+
+func TestBindingValidation_RejectsStatePrefixOnOutputVariable(t *testing.T) {
+	wf, err := New(Options{
+		Name: "bad-output",
+		Steps: []*Step{
+			{Name: "start", Activity: "a"},
+		},
+		Outputs: []*Output{
+			{Name: "final", Variable: "state.result"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrInvalidStorePath))
+}
+
+func TestBindingValidation_CollectsMultipleProblems(t *testing.T) {
+	wf, err := New(Options{
+		Name: "many-problems",
+		Steps: []*Step{
+			{
+				Name:     "start",
+				Activity: "missing",
+				Store:    "state.result",
+				Parameters: map[string]any{
+					"x": "$(!!bogus!!)",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.Error(t, err)
+
+	var ve *ValidationError
+	require.True(t, errors.As(err, &ve))
+	require.GreaterOrEqual(t, len(ve.Problems), 3)
+	require.True(t, errors.Is(err, ErrUnknownActivity))
+	require.True(t, errors.Is(err, ErrInvalidExpression))
+	require.True(t, errors.Is(err, ErrInvalidStorePath))
+}
+
+func TestBindingValidation_WaitSignalNoStoreWarnsNotErrors(t *testing.T) {
+	// No SignalStore configured — binding validation must NOT fail the
+	// build, only log a warning.
+	wf, err := New(Options{
+		Name: "wait-no-store",
+		Steps: []*Step{
+			{
+				Name: "gate",
+				WaitSignal: &WaitSignalConfig{
+					Topic:   "approved",
+					Timeout: time.Second,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
+	require.NoError(t, err)
 }
 
 func TestValidateRejectsModifierOnPauseStep(t *testing.T) {


### PR DESCRIPTION
## Summary

Phase-2 validation that runs after NewExecution binds the ActivityRegistry and script.Compiler:

- Unknown activity references → `ErrUnknownActivity`
- Parameter templates (`${...}`) and `$(…)` expressions compile → `ErrInvalidTemplate` / `ErrInvalidExpression`
- Edge condition expressions compile
- `WaitSignalConfig.Topic` templates compile
- Store fields (`Step.Store`, `WaitSignalConfig.Store`, `CatchConfig.Store`, `Output.Variable`) reject `state.` prefix → `ErrInvalidStorePath`
- Warn (do not error) when `WaitSignal` is used without a `SignalStore`

All problems collected into `*ValidationError` so `errors.Is` keeps working.

Updates tests and examples to use bare variable names for Store fields.

## Test plan
- [x] `make test-all`
- [x] New `TestBindingValidation_*` covers every new sentinel and the multi-problem collection path

🤖 Generated with [Claude Code](https://claude.com/claude-code)