### PR TITLE
PR6: Context becomes idiomatic Go

### DIFF
--- a/activities/child_workflow_activity_test.go
+++ b/activities/child_workflow_activity_test.go
@@ -24,7 +24,7 @@ func TestChildWorkflowActivity(t *testing.T) {
 		reg.Register(wf)
 
 		greetAct := workflow.ActivityFunc("greet", func(ctx workflow.Context, params map[string]any) (any, error) {
-			ctx.SetVariable("greeting", "hello from child")
+			ctx.Set("greeting", "hello from child")
 			return "hello", nil
 		})
 

--- a/activity_history.go
+++ b/activity_history.go
@@ -3,7 +3,7 @@ package workflow
 import "sync"
 
 // History is the per-activity-invocation persisted cache returned by
-// [ActivityHistory]. Activities use it to cache the result of expensive
+// Context.History. Activities use it to cache the result of expensive
 // or non-idempotent operations across wait-unwind replays: any value
 // recorded once survives the suspension + resume cycle, so a replayed
 // activity can pick up cached work without re-executing it.
@@ -13,7 +13,7 @@ import "sync"
 // cleared — no cross-step leakage.
 //
 // Use cases:
-//   - Caching LLM calls before a workflow.Wait so replays don't re-bill.
+//   - Caching LLM calls before a Context.Wait so replays don't re-bill.
 //   - Caching non-idempotent HTTP writes that can't be keyed off
 //     natural idempotency tokens.
 //   - Memoizing expensive computation inside an agent loop.
@@ -30,38 +30,6 @@ type History struct {
 	commit func(snapshot map[string]any)
 }
 
-// ActivityHistoryAware is the side interface that lets a
-// workflow.Context expose its activity history. The library's
-// executionContext implements it; wrappers and test doubles can embed
-// or delegate to preserve history access.
-type ActivityHistoryAware interface {
-	ActivityHistory() *History
-}
-
-// ActivityHistory returns the activity history cache for the current
-// activity invocation. If ctx does not implement [ActivityHistoryAware]
-// the returned cache is a process-local, non-persistent History — safe
-// to use but not durable across replays.
-//
-// Typical usage from an activity:
-//
-//	history := workflow.ActivityHistory(ctx)
-//	plan, err := history.RecordOrReplay("plan", func() (any, error) {
-//	    return llm.Plan(ctx, params)
-//	})
-//	if err != nil { return nil, err }
-//	// Expensive plan call only runs once across the lifetime of this
-//	// logical step, even if a subsequent workflow.Wait unwinds and
-//	// replays the activity.
-func ActivityHistory(ctx Context) *History {
-	if aware, ok := ctx.(ActivityHistoryAware); ok {
-		if h := aware.ActivityHistory(); h != nil {
-			return h
-		}
-	}
-	return newHistory(nil, nil)
-}
-
 // newHistory constructs a History seeded with the given entries and a
 // commit callback for persistence.
 func newHistory(initial map[string]any, commit func(map[string]any)) *History {
@@ -72,16 +40,22 @@ func newHistory(initial map[string]any, commit func(map[string]any)) *History {
 	return &History{entries: entries, commit: commit}
 }
 
+// NewHistoryForTest returns a fresh, non-persistent History for use
+// by test helpers (e.g. workflowtest.FakeContext).
+func NewHistoryForTest() *History {
+	return newHistory(nil, nil)
+}
+
 // RecordOrReplay runs fn on the first call for the given key and
 // caches its result. Subsequent calls for the same key — including
 // calls from activity replays after a wait-unwind — return the cached
-// value without invoking fn. If fn returns an error, no cache entry is
-// written and the error is returned unchanged.
+// value without invoking fn. If fn returns an error, no cache entry
+// is written and the error is returned unchanged.
 //
 // Concurrency: fn runs outside the history's lock so independent
-// RecordOrReplay calls can proceed in parallel. If two goroutines race
-// on the same key, both run fn, but only the first result is cached;
-// the second caller sees the cached first result.
+// RecordOrReplay calls can proceed in parallel. If two goroutines
+// race on the same key, both run fn, but only the first result is
+// cached; the second caller sees the cached first result.
 func (h *History) RecordOrReplay(key string, fn func() (any, error)) (any, error) {
 	h.mu.Lock()
 	if v, ok := h.entries[key]; ok {
@@ -110,7 +84,7 @@ func (h *History) RecordOrReplay(key string, fn func() (any, error)) (any, error
 
 // Get returns the cached value for key, if any, and whether it was
 // present. Exposed for testing and introspection; activities should
-// prefer [History.RecordOrReplay] for the normal cache-or-compute flow.
+// prefer History.RecordOrReplay for the normal cache-or-compute flow.
 func (h *History) Get(key string) (any, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/activity_history_test.go
+++ b/activity_history_test.go
@@ -27,7 +27,7 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 
 	agent := ActivityFunc("agent", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
-		history := ActivityHistory(ctx)
+		history := ctx.History()
 
 		plan, err := history.RecordOrReplay("plan", func() (any, error) {
 			atomic.AddInt32(&planCalls, 1)
@@ -45,7 +45,7 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 			return nil, err
 		}
 
-		reply, err := Wait(ctx, topic, time.Minute)
+		reply, err := ctx.Wait(topic, time.Minute)
 		if err != nil {
 			return nil, err
 		}
@@ -141,7 +141,7 @@ func TestActivityHistoryRecordOrReplayAcrossResume(t *testing.T) {
 func TestActivityHistoryErrorNotCached(t *testing.T) {
 	var calls int32
 	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
-		history := ActivityHistory(ctx)
+		history := ctx.History()
 
 		// First call fails.
 		_, err := history.RecordOrReplay("work", func() (any, error) {
@@ -188,7 +188,7 @@ func TestActivityHistoryScopedPerStep(t *testing.T) {
 	var aCalls, bCalls int32
 
 	stepA := ActivityFunc("a", func(ctx Context, p map[string]any) (any, error) {
-		history := ActivityHistory(ctx)
+		history := ctx.History()
 		_, err := history.RecordOrReplay("work", func() (any, error) {
 			atomic.AddInt32(&aCalls, 1)
 			return "a-result", nil
@@ -196,7 +196,7 @@ func TestActivityHistoryScopedPerStep(t *testing.T) {
 		return "a-done", err
 	})
 	stepB := ActivityFunc("b", func(ctx Context, p map[string]any) (any, error) {
-		history := ActivityHistory(ctx)
+		history := ctx.History()
 		// Same key as step A — should NOT be cached, since history is
 		// scoped per step.
 		_, err := history.RecordOrReplay("work", func() (any, error) {
@@ -240,7 +240,7 @@ func TestActivityHistoryNoOpWithoutContext(t *testing.T) {
 	// A bare executionContext without a History set should still
 	// return a working no-op cache.
 	ctx := &executionContext{Context: context.Background()}
-	history := ActivityHistory(ctx)
+	history := ctx.History()
 	require.NotNil(t, history)
 
 	var calls int32

--- a/branch.go
+++ b/branch.go
@@ -468,7 +468,7 @@ func (p *branch) executeStep(ctx context.Context, step *Step) (any, error) {
 			if result != nil {
 				valueToStore = result
 			}
-			p.state.SetVariable(varName, valueToStore)
+			p.state.Set(varName, valueToStore)
 		}
 	}
 
@@ -539,7 +539,7 @@ func (p *branch) handleWaitSignalStep(ctx context.Context, step *Step) (any, err
 		// normal progress; processBranchSnapshot will clear BranchState.Wait.
 		if cfg.Store != "" {
 			varName := strings.TrimPrefix(cfg.Store, "state.")
-			p.state.SetVariable(varName, sig.Payload)
+			p.state.Set(varName, sig.Payload)
 		}
 		return sig.Payload, nil
 	}
@@ -694,7 +694,7 @@ func (p *branch) handlePauseStep(ctx context.Context, step *Step) (any, error) {
 		// state transforms are preserved.
 		if specs[0].Variables != nil {
 			for k, v := range specs[0].Variables {
-				p.state.SetVariable(k, v)
+				p.state.Set(k, v)
 			}
 		}
 	}
@@ -989,7 +989,7 @@ func (p *branch) executeStepEach(ctx context.Context, step *Step) (any, error) {
 	var originalAsValue any
 	var hadOriginalAs bool
 	if each.As != "" {
-		originalAsValue, hadOriginalAs = p.state.GetVariable(each.As)
+		originalAsValue, hadOriginalAs = p.state.Get(each.As)
 	}
 
 	// restoreAs cleans up the iteration variable regardless of how the
@@ -999,9 +999,9 @@ func (p *branch) executeStepEach(ctx context.Context, step *Step) (any, error) {
 			return
 		}
 		if hadOriginalAs {
-			p.state.SetVariable(each.As, originalAsValue)
+			p.state.Set(each.As, originalAsValue)
 		} else {
-			p.state.DeleteVariable(each.As)
+			p.state.Delete(each.As)
 		}
 	}
 
@@ -1009,7 +1009,7 @@ func (p *branch) executeStepEach(ctx context.Context, step *Step) (any, error) {
 	for _, item := range items {
 		// Prepare additional parameters for this iteration
 		if each.As != "" {
-			p.state.SetVariable(each.As, item)
+			p.state.Set(each.As, item)
 		}
 
 		// Prepare parameters for this iteration
@@ -1033,7 +1033,7 @@ func (p *branch) executeStepEach(ctx context.Context, step *Step) (any, error) {
 	// Store result directly in branch variables if specified
 	if step.Store != "" {
 		varName := strings.TrimPrefix(step.Store, "state.")
-		p.state.SetVariable(varName, results)
+		p.state.Set(varName, results)
 	}
 	return results, nil
 }
@@ -1165,7 +1165,7 @@ func (p *branch) executeCatchHandler(step *Step, err error) (any, error) {
 				if catchConfig.Store != "" {
 					resultPath := strings.TrimPrefix(catchConfig.Store, "state.")
 					if resultPath != "" {
-						p.state.SetVariable(resultPath, errorOutput)
+						p.state.Set(resultPath, errorOutput)
 					}
 				}
 

--- a/branch_join_test.go
+++ b/branch_join_test.go
@@ -64,16 +64,16 @@ func TestBranchJoining(t *testing.T) {
 					return 10, nil
 				}))
 		reg.MustRegister(ActivityFunc("double", func(ctx Context, params map[string]any) (any, error) {
-					value, _ := ctx.GetVariable("value")
+					value, _ := ctx.Get("value")
 					return value.(int) * 2, nil
 				}))
 		reg.MustRegister(ActivityFunc("triple", func(ctx Context, params map[string]any) (any, error) {
-					value, _ := ctx.GetVariable("value")
+					value, _ := ctx.Get("value")
 					return value.(int) * 3, nil
 				}))
 		reg.MustRegister(ActivityFunc("sum", func(ctx Context, params map[string]any) (any, error) {
-					doubled, _ := ctx.GetVariable("doubled")
-					tripled, _ := ctx.GetVariable("tripled")
+					doubled, _ := ctx.Get("doubled")
+					tripled, _ := ctx.Get("tripled")
 					return doubled.(int) + tripled.(int), nil
 				}))
 		execution, err := NewExecution(wf, reg,
@@ -149,18 +149,18 @@ func TestBranchJoining(t *testing.T) {
 					return 5, nil
 				}))
 		reg2.MustRegister(ActivityFunc("work_x", func(ctx Context, params map[string]any) (any, error) {
-					ctx.SetVariable("x_meta", "x_processed")
-					base, _ := ctx.GetVariable("base")
+					ctx.Set("x_meta", "x_processed")
+					base, _ := ctx.Get("base")
 					return base.(int) * 4, nil
 				}))
 		reg2.MustRegister(ActivityFunc("work_y", func(ctx Context, params map[string]any) (any, error) {
-					ctx.SetVariable("y_meta", "y_processed")
-					base, _ := ctx.GetVariable("base")
+					ctx.Set("y_meta", "y_processed")
+					base, _ := ctx.Get("base")
 					return base.(int) * 6, nil
 				}))
 		reg2.MustRegister(ActivityFunc("combine", func(ctx Context, params map[string]any) (any, error) {
-					pathX, _ := ctx.GetVariable("path_x")
-					pathY, _ := ctx.GetVariable("path_y")
+					pathX, _ := ctx.Get("path_x")
+					pathY, _ := ctx.Get("path_y")
 
 					pathXMap := pathX.(map[string]any)
 					pathYMap := pathY.(map[string]any)

--- a/branch_local_state.go
+++ b/branch_local_state.go
@@ -5,9 +5,13 @@ import (
 	"sync"
 )
 
-// BranchLocalState provides activities with access to workflow input variables
-// and to the execution branch's copy of state variables. It is safe for
-// concurrent use.
+// BranchLocalState provides activities with access to workflow input
+// variables and to the execution branch's copy of state variables. It
+// is safe for concurrent use.
+//
+// BranchLocalState is embedded in executionContext so its methods
+// bubble up as the Context.Get/Set/Delete/Keys methods activity code
+// uses directly.
 type BranchLocalState struct {
 	mu        sync.RWMutex
 	inputs    map[string]any
@@ -21,40 +25,26 @@ func NewBranchLocalState(inputs, variables map[string]any) *BranchLocalState {
 	}
 }
 
-func (s *BranchLocalState) ListInputs() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	var keys []string
-	for key := range s.inputs {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
-func (s *BranchLocalState) GetInput(key string) (any, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	value, exists := s.inputs[key]
-	return value, exists
-}
-
-func (s *BranchLocalState) SetVariable(key string, value any) {
+// Set writes a branch-local variable.
+func (s *BranchLocalState) Set(key string, value any) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.variables[key] = value
 }
 
-func (s *BranchLocalState) DeleteVariable(key string) {
+// Delete removes a branch-local variable.
+func (s *BranchLocalState) Delete(key string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.variables, key)
 }
 
-func (s *BranchLocalState) ListVariables() []string {
+// Keys returns the names of all branch-local variables in sorted
+// order.
+func (s *BranchLocalState) Keys() []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	var keys []string
+	keys := make([]string, 0, len(s.variables))
 	for key := range s.variables {
 		keys = append(keys, key)
 	}
@@ -62,9 +52,29 @@ func (s *BranchLocalState) ListVariables() []string {
 	return keys
 }
 
-func (s *BranchLocalState) GetVariable(key string) (any, bool) {
+// Get returns a branch-local variable and whether it was present.
+func (s *BranchLocalState) Get(key string) (any, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	value, exists := s.variables[key]
 	return value, exists
+}
+
+// inputsSnapshot returns a copy of the input map for use by
+// executionContext.Inputs. The snapshot is the stable view exposed
+// to activity code — once taken, later writes do not affect it.
+func (s *BranchLocalState) inputsSnapshot() map[string]any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]any, len(s.inputs))
+	for k, v := range s.inputs {
+		out[k] = v
+	}
+	return out
+}
+
+// variablesMap returns the underlying map by reference. Internal-only
+// accessor used by the engine for state snapshot/restore under lock.
+func (s *BranchLocalState) variablesMap() map[string]any {
+	return s.variables
 }

--- a/branch_test.go
+++ b/branch_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/deepnoodle-ai/workflow/internal/require"
 	"github.com/deepnoodle-ai/workflow/script"
@@ -469,18 +470,18 @@ type MockContext struct {
 	variables map[string]any
 }
 
-func (m *MockContext) SetVariable(key string, value any) {
+func (m *MockContext) Set(key string, value any) {
 	if m.variables == nil {
 		m.variables = make(map[string]any)
 	}
 	m.variables[key] = value
 }
 
-func (m *MockContext) DeleteVariable(key string) {
+func (m *MockContext) Delete(key string) {
 	delete(m.variables, key)
 }
 
-func (m *MockContext) ListVariables() []string {
+func (m *MockContext) Keys() []string {
 	var keys []string
 	for k := range m.variables {
 		keys = append(keys, k)
@@ -488,34 +489,40 @@ func (m *MockContext) ListVariables() []string {
 	return keys
 }
 
-func (m *MockContext) GetVariable(key string) (any, bool) {
+func (m *MockContext) Get(key string) (any, bool) {
 	v, ok := m.variables[key]
 	return v, ok
 }
 
-func (m *MockContext) ListInputs() []string {
-	return []string{}
+func (m *MockContext) Inputs() Inputs {
+	return Inputs{}
 }
 
-func (m *MockContext) GetInput(key string) (any, bool) {
-	return nil, false
-}
-
-func (m *MockContext) GetLogger() *slog.Logger {
+func (m *MockContext) Logger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-func (m *MockContext) GetCompiler() script.Compiler {
+func (m *MockContext) Compiler() script.Compiler {
 	return newTestCompiler()
 }
 
-func (m *MockContext) GetBranchID() string {
+func (m *MockContext) BranchID() string {
 	return "test-branch"
 }
 
-func (m *MockContext) GetStepName() string {
+func (m *MockContext) StepName() string {
 	return "test-step"
 }
+
+func (m *MockContext) Wait(topic string, timeout time.Duration) (any, error) {
+	return nil, nil
+}
+
+func (m *MockContext) History() *History {
+	return newHistory(nil, nil)
+}
+
+func (m *MockContext) ReportProgress(detail ProgressDetail) {}
 
 func TestExecuteStepEach(t *testing.T) {
 	// Create test workflow and step
@@ -588,7 +595,7 @@ func TestExecuteStepEach(t *testing.T) {
 		branch := newBranch("test-branch", step, pathOpts)
 
 		// Verify original "fruit" variable
-		fruit, ok := branch.state.GetVariable("fruit")
+		fruit, ok := branch.state.Get("fruit")
 		require.True(t, ok)
 		require.Equal(t, "mango", fruit)
 
@@ -607,12 +614,12 @@ func TestExecuteStepEach(t *testing.T) {
 		}
 
 		// Original "fruit" variable should be restored
-		fruit, ok = branch.state.GetVariable("fruit")
+		fruit, ok = branch.state.Get("fruit")
 		require.True(t, ok)
 		require.Equal(t, "mango", fruit)
 
 		// Verify the_results variable
-		results, ok := branch.state.GetVariable("the_results")
+		results, ok := branch.state.Get("the_results")
 		require.True(t, ok)
 		require.Equal(t, []any{"apple", "banana", "cherry"}, results)
 	})
@@ -682,7 +689,7 @@ func TestExecuteCatchHandler(t *testing.T) {
 		require.Equal(t, "step-a", branch.currentStep.Name)
 
 		// Should store error in branch variables
-		storedError, exists := branch.state.GetVariable("last_error")
+		storedError, exists := branch.state.Get("last_error")
 		require.True(t, exists, "Error should be stored in variables")
 
 		// Verify stored error structure
@@ -720,7 +727,7 @@ func TestExecuteCatchHandler(t *testing.T) {
 		require.Equal(t, "step-b", branch.currentStep.Name)
 
 		// Should store error in branch variables (without "state." prefix)
-		storedError, exists := branch.state.GetVariable("error_info")
+		storedError, exists := branch.state.Get("error_info")
 		require.True(t, exists, "Error should be stored in variables")
 
 		errorOutput := storedError.(ErrorOutput)
@@ -756,7 +763,7 @@ func TestExecuteCatchHandler(t *testing.T) {
 		require.Equal(t, "step-c", branch.currentStep.Name)
 
 		// Should not store anything in variables
-		_, exists := branch.state.GetVariable("error_info")
+		_, exists := branch.state.Get("error_info")
 		require.False(t, exists, "No error should be stored when Store is not specified")
 	})
 
@@ -793,8 +800,8 @@ func TestExecuteCatchHandler(t *testing.T) {
 		require.Equal(t, "step-a", branch.currentStep.Name)
 
 		// Should store in timeout_error, not general_error
-		_, timeoutExists := branch.state.GetVariable("timeout_error")
-		_, generalExists := branch.state.GetVariable("general_error")
+		_, timeoutExists := branch.state.Get("timeout_error")
+		_, generalExists := branch.state.Get("general_error")
 		require.True(t, timeoutExists, "Should store in first matching handler")
 		require.False(t, generalExists, "Should not store in second handler")
 	})
@@ -883,7 +890,7 @@ func TestExecuteCatchHandler(t *testing.T) {
 		require.Equal(t, "step-a", branch.currentStep.Name)
 
 		// Should store custom error
-		storedError, exists := branch.state.GetVariable("permission_error")
+		storedError, exists := branch.state.Get("permission_error")
 		require.True(t, exists)
 
 		errorOutput := storedError.(ErrorOutput)

--- a/context.go
+++ b/context.go
@@ -2,8 +2,8 @@ package workflow
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/deepnoodle-ai/workflow/script"
@@ -11,45 +11,114 @@ import (
 
 var _ Context = &executionContext{}
 
-// Context is a superset of of context.Context that provides access to workflow
-// execution metadata and state.
+// Context is the activity-facing extension of context.Context. It
+// exposes the workflow inputs, the branch-local state map, progress
+// and signal plumbing, and the small identity values an activity may
+// want to log.
+//
+// The interface is idiomatic Go: property-style accessors (Logger,
+// BranchID, StepName) rather than GetLogger/GetBranchID, and the
+// variable store methods are the ones you'd expect on a map.
+//
+// All methods are safe for concurrent use.
 type Context interface {
-
-	// workflow.Context embeds the context.Context interface.
 	context.Context
 
-	// workflow.Context embeds the VariableContainer interface.
-	VariableContainer
+	// Inputs returns a read-only view over the workflow inputs for
+	// this branch.
+	Inputs() Inputs
 
-	// ListInputs returns a slice containing all input names.
-	ListInputs() []string
+	// Set writes a branch-local variable.
+	Set(key string, value any)
+	// Get returns a branch-local variable and whether it was present.
+	Get(key string) (value any, exists bool)
+	// Delete removes a branch-local variable.
+	Delete(key string)
+	// Keys returns the names of all branch-local variables in sorted
+	// order.
+	Keys() []string
 
-	// GetInput returns the value of an input variable.
-	GetInput(key string) (value any, exists bool)
+	// Logger returns the slog.Logger configured on the execution,
+	// scoped to this execution and branch.
+	Logger() *slog.Logger
+	// Compiler returns the script.Compiler configured on the
+	// execution.
+	Compiler() script.Compiler
+	// BranchID returns the ID of the running branch.
+	BranchID() string
+	// StepName returns the name of the currently executing step.
+	StepName() string
 
-	// GetLogger returns the logger.
-	GetLogger() *slog.Logger
+	// Wait durably waits for a signal on the given topic. See the
+	// package-level documentation on the wait behaviour, replay
+	// safety, and the multi-wait pattern in
+	// planning/prds/002-signals-waits-pausing.md.
+	Wait(topic string, timeout time.Duration) (any, error)
+	// History returns the per-activity-invocation persisted cache.
+	// Returns a process-local, non-persistent cache if called outside
+	// of an activity invocation.
+	History() *History
+	// ReportProgress forwards a progress update to the configured
+	// StepProgressStore, if any. No-op otherwise.
+	ReportProgress(detail ProgressDetail)
+}
 
-	// GetCompiler returns the script compiler.
-	GetCompiler() script.Compiler
+// Inputs is a read-only view over workflow input values. It exists as
+// a named type so we can grow it with typed accessors (GetString,
+// GetInt) in the future without breaking the Context interface.
+type Inputs struct {
+	m map[string]any
+}
 
-	// GetBranchID returns the current execution branch ID.
-	GetBranchID() string
+// newInputs builds an Inputs from a snapshot map. The map is not
+// copied — callers that need mutation safety must pass a copy.
+func newInputs(m map[string]any) Inputs {
+	return Inputs{m: m}
+}
 
-	// GetStepName returns the current step name.
-	GetStepName() string
+// NewInputsForTest builds an Inputs from a snapshot map for use by
+// test helpers (e.g. workflowtest.FakeContext). The map is taken by
+// reference; callers that need mutation safety must pass a copy.
+func NewInputsForTest(m map[string]any) Inputs {
+	return Inputs{m: m}
+}
+
+// Get returns the value of an input and whether it was present.
+func (i Inputs) Get(key string) (any, bool) {
+	v, ok := i.m[key]
+	return v, ok
+}
+
+// Keys returns the input names in sorted order.
+func (i Inputs) Keys() []string {
+	keys := make([]string, 0, len(i.m))
+	for k := range i.m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Len returns the number of inputs.
+func (i Inputs) Len() int { return len(i.m) }
+
+// ToMap returns a copy of the inputs as a plain map. Mutating the
+// returned map does not affect the underlying execution state.
+func (i Inputs) ToMap() map[string]any {
+	out := make(map[string]any, len(i.m))
+	for k, v := range i.m {
+		out[k] = v
+	}
+	return out
 }
 
 // executionContext implements the workflow.Context interface.
-// It also optionally implements ProgressReporter when a StepProgressStore
-// is configured, [SignalAware] for workflow.Wait, and
-// [ActivityHistoryAware] for workflow.ActivityHistory.
 type executionContext struct {
 	context.Context
 	*BranchLocalState
 	logger           *slog.Logger
 	compiler         script.Compiler
-	branchID           string
+	branchID         string
 	stepName         string
 	executionID      string
 	signalStore      SignalStore
@@ -60,12 +129,12 @@ type executionContext struct {
 
 type ExecutionContextOptions struct {
 	BranchLocalState *BranchLocalState
-	Logger         *slog.Logger
-	Compiler       script.Compiler
+	Logger           *slog.Logger
+	Compiler         script.Compiler
 	BranchID         string
-	StepName       string
-	ExecutionID    string
-	SignalStore    SignalStore
+	StepName         string
+	ExecutionID      string
+	SignalStore      SignalStore
 	// PendingWait is the wait state the branch was parked on before the
 	// current activity invocation, if any. Set by the engine when a
 	// checkpoint is being replayed so workflow.Wait can reuse the
@@ -78,83 +147,79 @@ type ExecutionContextOptions struct {
 	ActivityHistory *History
 }
 
-// NewContext creates a new workflow context with direct state access
+// NewContext creates a new workflow context with direct state access.
 func NewContext(ctx context.Context, opts ExecutionContextOptions) *executionContext {
 	return &executionContext{
-		Context:        ctx,
+		Context:          ctx,
 		BranchLocalState: opts.BranchLocalState,
-		logger:         opts.Logger,
-		compiler:       opts.Compiler,
+		logger:           opts.Logger,
+		compiler:         opts.Compiler,
 		branchID:         opts.BranchID,
-		stepName:       opts.StepName,
-		executionID:    opts.ExecutionID,
-		signalStore:    opts.SignalStore,
-		pendingWait:    opts.PendingWait,
-		history:        opts.ActivityHistory,
+		stepName:         opts.StepName,
+		executionID:      opts.ExecutionID,
+		signalStore:      opts.SignalStore,
+		pendingWait:      opts.PendingWait,
+		history:          opts.ActivityHistory,
 	}
 }
 
-// ActivityHistory implements [ActivityHistoryAware] so
-// workflow.ActivityHistory(ctx) can reach the persisted cache for
-// this activity invocation.
-func (w *executionContext) ActivityHistory() *History {
-	return w.history
+// Inputs returns a read-only view over this branch's inputs.
+func (w *executionContext) Inputs() Inputs {
+	if w.BranchLocalState == nil {
+		return Inputs{}
+	}
+	return newInputs(w.BranchLocalState.inputsSnapshot())
 }
 
-// SignalStore implements SignalAware.
-func (w *executionContext) SignalStore() SignalStore {
-	return w.signalStore
-}
+// Logger returns the logger for this workflow context.
+func (w *executionContext) Logger() *slog.Logger { return w.logger }
 
-// ExecutionID implements SignalAware.
-func (w *executionContext) ExecutionID() string {
-	return w.executionID
-}
+// Compiler returns the script compiler for this workflow context.
+func (w *executionContext) Compiler() script.Compiler { return w.compiler }
 
-// PendingWait implements SignalAware.
-func (w *executionContext) PendingWait() *WaitState {
-	return w.pendingWait
-}
+// BranchID returns the current branch ID.
+func (w *executionContext) BranchID() string { return w.branchID }
 
-// GetLogger returns the logger for this workflow context
-func (w *executionContext) GetLogger() *slog.Logger {
-	return w.logger
-}
+// StepName returns the current step name.
+func (w *executionContext) StepName() string { return w.stepName }
 
-// GetCompiler returns the script compiler for this workflow context
-func (w *executionContext) GetCompiler() script.Compiler {
-	return w.compiler
-}
-
-// GetBranchID returns the current branch ID
-func (w *executionContext) GetBranchID() string {
-	return w.branchID
-}
-
-// GetStepName returns the current step name
-func (w *executionContext) GetStepName() string {
-	return w.stepName
-}
-
-// ReportProgress implements the ProgressReporter interface.
+// ReportProgress forwards the progress detail to the configured
+// StepProgressStore, if any.
 func (w *executionContext) ReportProgress(detail ProgressDetail) {
 	if w.progressReporter != nil {
 		w.progressReporter(detail)
 	}
 }
 
+// History returns the per-activity-invocation persisted cache for
+// this step. If the context was not constructed with one (e.g. it
+// belongs to a handler, not an activity), a process-local,
+// non-persistent cache is returned so callers never need a nil check.
+func (w *executionContext) History() *History {
+	if w.history == nil {
+		return newHistory(nil, nil)
+	}
+	return w.history
+}
+
+// internal accessors for the signal and wait subsystems. They are not
+// part of the exported Context interface but let wait.go reach the
+// plumbing without re-opening the struct.
+func (w *executionContext) signalStoreInternal() SignalStore { return w.signalStore }
+func (w *executionContext) executionIDInternal() string      { return w.executionID }
+func (w *executionContext) pendingWaitInternal() *WaitState  { return w.pendingWait }
+
 // WithTimeout creates a new workflow context with a timeout.
 func WithTimeout(parent Context, timeout time.Duration) (Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(parent, timeout)
 
-	// If parent is a workflow context, preserve its workflow-specific data
 	if wc, ok := parent.(*executionContext); ok {
 		return &executionContext{
 			Context:          ctx,
-			BranchLocalState:   wc.BranchLocalState,
+			BranchLocalState: wc.BranchLocalState,
 			logger:           wc.logger,
 			compiler:         wc.compiler,
-			branchID:           wc.branchID,
+			branchID:         wc.branchID,
 			stepName:         wc.stepName,
 			executionID:      wc.executionID,
 			signalStore:      wc.signalStore,
@@ -164,8 +229,6 @@ func WithTimeout(parent Context, timeout time.Duration) (Context, context.Cancel
 		}, cancel
 	}
 
-	// This shouldn't happen in normal workflow execution
-	// Return a basic context that doesn't support workflow methods
 	return &executionContext{Context: ctx}, cancel
 }
 
@@ -173,14 +236,13 @@ func WithTimeout(parent Context, timeout time.Duration) (Context, context.Cancel
 func WithCancel(parent Context) (Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
 
-	// If parent is a workflow context, preserve its workflow-specific data
 	if wc, ok := parent.(*executionContext); ok {
 		return &executionContext{
 			Context:          ctx,
-			BranchLocalState:   wc.BranchLocalState,
+			BranchLocalState: wc.BranchLocalState,
 			logger:           wc.logger,
 			compiler:         wc.compiler,
-			branchID:           wc.branchID,
+			branchID:         wc.branchID,
 			stepName:         wc.stepName,
 			executionID:      wc.executionID,
 			signalStore:      wc.signalStore,
@@ -190,37 +252,5 @@ func WithCancel(parent Context) (Context, context.CancelFunc) {
 		}, cancel
 	}
 
-	// This shouldn't happen in normal workflow execution
-	// Return a basic context that doesn't support workflow methods
 	return &executionContext{Context: ctx}, cancel
-}
-
-// VariablesFromContext returns a map of all variables in the context. This is
-// a copy. Any changes made to this map will not persist.
-func VariablesFromContext(ctx Context) map[string]any {
-	keys := ctx.ListVariables()
-	variables := make(map[string]any, len(keys))
-	for _, key := range keys {
-		var found bool
-		variables[key], found = ctx.GetVariable(key)
-		if !found { // Should never happen
-			panic(fmt.Errorf("variable %s not found in context", key))
-		}
-	}
-	return variables
-}
-
-// InputsFromContext returns a map of all inputs in the context. This is a copy.
-// Any changes made to this map will not persist.
-func InputsFromContext(ctx Context) map[string]any {
-	keys := ctx.ListInputs()
-	inputs := make(map[string]any, len(keys))
-	for _, key := range keys {
-		var found bool
-		inputs[key], found = ctx.GetInput(key)
-		if !found { // Should never happen
-			panic(fmt.Errorf("input %s not found in context", key))
-		}
-	}
-	return inputs
 }

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/deepnoodle-ai/workflow/internal/require"
 )
 
-// --- VariableContainer / Patches ---
+// --- Patches ---
 
 func TestNewPatch(t *testing.T) {
 	p := newPatch(patchOptions{Variable: "key", Value: "val", Delete: false})
@@ -35,44 +35,45 @@ func TestApplyPatches(t *testing.T) {
 	}
 	applyPatches(state, patches)
 
-	v, ok := state.GetVariable("a")
+	v, ok := state.Get("a")
 	require.True(t, ok)
 	require.Equal(t, 10, v)
 
-	_, ok = state.GetVariable("b")
+	_, ok = state.Get("b")
 	require.False(t, ok)
 
-	v, ok = state.GetVariable("c")
+	v, ok = state.Get("c")
 	require.True(t, ok)
 	require.Equal(t, "new", v)
 }
 
 // --- BranchLocalState ---
 
-func TestBranchLocalState_ListInputs(t *testing.T) {
+func TestBranchLocalState_Inputs(t *testing.T) {
 	state := NewBranchLocalState(map[string]any{"z": 1, "a": 2, "m": 3}, nil)
-	keys := state.ListInputs()
-	require.Equal(t, []string{"a", "m", "z"}, keys)
+	snapshot := state.inputsSnapshot()
+	require.Equal(t, map[string]any{"z": 1, "a": 2, "m": 3}, snapshot)
 }
 
-func TestBranchLocalState_GetInput(t *testing.T) {
+func TestBranchLocalState_InputsGet(t *testing.T) {
 	state := NewBranchLocalState(map[string]any{"key": "value"}, nil)
-	v, ok := state.GetInput("key")
+	inputs := newInputs(state.inputsSnapshot())
+	v, ok := inputs.Get("key")
 	require.True(t, ok)
 	require.Equal(t, "value", v)
 
-	_, ok = state.GetInput("missing")
+	_, ok = inputs.Get("missing")
 	require.False(t, ok)
 }
 
-func TestBranchLocalState_DeleteVariable(t *testing.T) {
+func TestBranchLocalState_Delete(t *testing.T) {
 	state := NewBranchLocalState(nil, map[string]any{"a": 1, "b": 2})
-	state.DeleteVariable("a")
+	state.Delete("a")
 
-	_, ok := state.GetVariable("a")
+	_, ok := state.Get("a")
 	require.False(t, ok)
 
-	v, ok := state.GetVariable("b")
+	v, ok := state.Get("b")
 	require.True(t, ok)
 	require.Equal(t, 2, v)
 }
@@ -92,10 +93,10 @@ func TestContextGetters(t *testing.T) {
 		StepName:       "step-1",
 	})
 
-	require.Equal(t, logger, ctx.GetLogger())
-	require.Equal(t, compiler, ctx.GetCompiler())
-	require.Equal(t, "branch-1", ctx.GetBranchID())
-	require.Equal(t, "step-1", ctx.GetStepName())
+	require.Equal(t, logger, ctx.Logger())
+	require.Equal(t, compiler, ctx.Compiler())
+	require.Equal(t, "branch-1", ctx.BranchID())
+	require.Equal(t, "step-1", ctx.StepName())
 }
 
 func TestWithTimeout(t *testing.T) {
@@ -109,11 +110,11 @@ func TestWithTimeout(t *testing.T) {
 	child, cancel := WithTimeout(parent, 5*time.Second)
 	defer cancel()
 
-	require.Equal(t, "p1", child.GetBranchID())
-	require.Equal(t, "s1", child.GetStepName())
+	require.Equal(t, "p1", child.BranchID())
+	require.Equal(t, "s1", child.StepName())
 
 	// Verify variable access still works
-	v, ok := child.GetVariable("v")
+	v, ok := child.Get("v")
 	require.True(t, ok)
 	require.Equal(t, 2, v)
 }
@@ -138,8 +139,8 @@ func TestWithCancel(t *testing.T) {
 	child, cancel := WithCancel(parent)
 	defer cancel()
 
-	require.Equal(t, "p1", child.GetBranchID())
-	require.Equal(t, "s1", child.GetStepName())
+	require.Equal(t, "p1", child.BranchID())
+	require.Equal(t, "s1", child.StepName())
 }
 
 func TestWithCancel_NonWorkflowContext(t *testing.T) {
@@ -154,8 +155,13 @@ func TestInputsFromContext(t *testing.T) {
 	ctx := NewContext(context.Background(), ExecutionContextOptions{
 		BranchLocalState: state,
 	})
-	inputs := InputsFromContext(ctx)
-	require.Equal(t, map[string]any{"a": 1, "b": "two"}, inputs)
+	inputs := ctx.Inputs()
+	require.Equal(t, map[string]any{"a": 1, "b": "two"}, inputs.ToMap())
+	require.Equal(t, 2, inputs.Len())
+	require.Equal(t, []string{"a", "b"}, inputs.Keys())
+	v, ok := inputs.Get("a")
+	require.True(t, ok)
+	require.Equal(t, 1, v)
 }
 
 // --- ValidationError ---
@@ -498,7 +504,7 @@ func TestDefaultChildWorkflowExecutor_ExecuteSync(t *testing.T) {
 	reg.Register(wf)
 
 	greetActivity := ActivityFunc("greet", func(ctx Context, params map[string]any) (any, error) {
-		ctx.SetVariable("greeting", "hello")
+		ctx.Set("greeting", "hello")
 		return "hello", nil
 	})
 
@@ -818,7 +824,7 @@ func TestExecution_WithStepProgressStore(t *testing.T) {
 	require.NoError(t, err)
 
 	workActivity := ActivityFunc("work", func(ctx Context, params map[string]any) (any, error) {
-		ReportProgress(ctx, ProgressDetail{Message: "halfway", Data: map[string]any{"pct": 50}})
+		ctx.ReportProgress(ProgressDetail{Message: "halfway", Data: map[string]any{"pct": 50}})
 		return "done", nil
 	})
 
@@ -915,7 +921,7 @@ func TestExecution_Execute(t *testing.T) {
 	require.NoError(t, err)
 
 	echoActivity := ActivityFunc("echo", func(ctx Context, params map[string]any) (any, error) {
-		ctx.SetVariable("msg", "hello")
+		ctx.Set("msg", "hello")
 		return "hello", nil
 	})
 
@@ -963,7 +969,7 @@ func TestDefaultChildWorkflowExecutor_AsyncFlow(t *testing.T) {
 	reg.Register(wf)
 
 	greetActivity := ActivityFunc("greet", func(ctx Context, params map[string]any) (any, error) {
-		ctx.SetVariable("msg", "async hello")
+		ctx.Set("msg", "async hello")
 		return "done", nil
 	})
 
@@ -1035,7 +1041,7 @@ func TestExecution_Branching(t *testing.T) {
 	require.NoError(t, err)
 
 	setFlag := ActivityFunc("set-flag", func(ctx Context, params map[string]any) (any, error) {
-		ctx.SetVariable("flag", true)
+		ctx.Set("flag", true)
 		return nil, nil
 	})
 	noop := ActivityFunc("noop", func(ctx Context, params map[string]any) (any, error) {
@@ -1079,7 +1085,7 @@ func TestExecution_CatchHandler(t *testing.T) {
 		return nil, fmt.Errorf("something broke")
 	})
 	recoverIt := ActivityFunc("recover-it", func(ctx Context, params map[string]any) (any, error) {
-		ctx.SetVariable("recovered", true)
+		ctx.Set("recovered", true)
 		return "recovered", nil
 	})
 	noop := ActivityFunc("noop", func(ctx Context, params map[string]any) (any, error) {
@@ -1296,7 +1302,7 @@ func TestExecution_EachStep_CleansUpAsVariable(t *testing.T) {
 	checkAct := ActivityFunc("check-leak", func(ctx Context, params map[string]any) (any, error) {
 		// The "item" variable should not exist after the each loop since
 		// it didn't exist before.
-		_, exists := ctx.GetVariable("item")
+		_, exists := ctx.Get("item")
 		if exists {
 			return nil, fmt.Errorf("'item' variable leaked from each loop")
 		}
@@ -1343,7 +1349,7 @@ func TestExecution_StoreResult(t *testing.T) {
 		return 42, nil
 	})
 	checkActivity := ActivityFunc("check", func(ctx Context, params map[string]any) (any, error) {
-		v, ok := ctx.GetVariable("result")
+		v, ok := ctx.Get("result")
 		if !ok {
 			return nil, fmt.Errorf("result not found in state")
 		}

--- a/examples/join_branches/main.go
+++ b/examples/join_branches/main.go
@@ -76,7 +76,7 @@ func main() {
 		fmt.Println("⚙️  branch A: Processing...")
 		time.Sleep(100 * time.Millisecond)
 
-		initialValue, _ := ctx.GetVariable("initial_value")
+		initialValue, _ := ctx.Get("initial_value")
 		result := initialValue.(int) * 2
 		fmt.Printf("   branch A result: %d\n", result)
 		return result, nil
@@ -85,7 +85,7 @@ func main() {
 		fmt.Println("⚙️  branch B: Processing...")
 		time.Sleep(150 * time.Millisecond)
 
-		initialValue, _ := ctx.GetVariable("initial_value")
+		initialValue, _ := ctx.Get("initial_value")
 		result := initialValue.(int) * 3
 		fmt.Printf("   branch B result: %d\n", result)
 		return result, nil
@@ -94,8 +94,8 @@ func main() {
 		fmt.Println("🔗 Combining results...")
 
 		// Access the extracted values directly
-		valueA, _ := ctx.GetVariable("valueA")
-		valueB, _ := ctx.GetVariable("valueB")
+		valueA, _ := ctx.Get("valueA")
+		valueB, _ := ctx.Get("valueB")
 
 		resultA := valueA.(int)
 		resultB := valueB.(int)

--- a/examples/step_progress/main.go
+++ b/examples/step_progress/main.go
@@ -81,12 +81,12 @@ func main() {
 	reg.MustRegister(workflow.TypedActivityFunc("transform",
 		func(ctx workflow.Context, params map[string]any) (any, error) {
 			// Report intra-activity progress
-			workflow.ReportProgress(ctx, workflow.ProgressDetail{
+			ctx.ReportProgress(workflow.ProgressDetail{
 				Message: "Transforming batch 1 of 2",
 			})
 			time.Sleep(50 * time.Millisecond)
 
-			workflow.ReportProgress(ctx, workflow.ProgressDetail{
+			ctx.ReportProgress(workflow.ProgressDetail{
 				Message: "Transforming batch 2 of 2",
 				Data:    map[string]any{"batch": 2, "total": 2},
 			})

--- a/execution.go
+++ b/execution.go
@@ -1120,7 +1120,7 @@ func (e *Execution) processJoinCompletion(ctx context.Context, stepName string, 
 
 	// Update the waiting branch's variables with merged state
 	for key, value := range mergedVariables {
-		continuingBranch.state.SetVariable(key, value)
+		continuingBranch.state.Set(key, value)
 	}
 
 	// Update branch state to show it's running again

--- a/execution_state.go
+++ b/execution_state.go
@@ -35,7 +35,7 @@ type BranchState struct {
 	// ActivityHistory is the persisted cache for the currently
 	// executing activity. It survives wait-unwind replays so
 	// activities can cache expensive work across suspensions via
-	// [workflow.ActivityHistory] + [History.RecordOrReplay]. Cleared
+	// [Context.History] + [History.RecordOrReplay]. Cleared
 	// when the step advances past the activity so there is no
 	// cross-step leakage.
 	ActivityHistory map[string]any `json:"activity_history,omitempty"`

--- a/execution_test.go
+++ b/execution_test.go
@@ -825,9 +825,14 @@ func TestBranchBranching(t *testing.T) {
 			executionMutex.Lock()
 			defer executionMutex.Unlock()
 
+			data := make(map[string]any)
+			for _, k := range ctx.Keys() {
+				v, _ := ctx.Get(k)
+				data[k] = v
+			}
 			executions = append(executions, ActivityExecution{
 				Activity: activity,
-				PathData: copyMap(VariablesFromContext(ctx)),
+				PathData: data,
 			})
 		}
 
@@ -879,17 +884,17 @@ func TestBranchBranching(t *testing.T) {
 				}))
 		reg2.MustRegister(ActivityFunc("process_small", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "process_small")
-					ctx.SetVariable("branch_type", "small")
+					ctx.Set("branch_type", "small")
 					return "small processed", nil
 				}))
 		reg2.MustRegister(ActivityFunc("process_medium", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "process_medium")
-					ctx.SetVariable("branch_type", "medium")
+					ctx.Set("branch_type", "medium")
 					return "medium processed", nil
 				}))
 		reg2.MustRegister(ActivityFunc("process_large", func(ctx Context, params map[string]any) (any, error) {
 					recordExecution(ctx, "process_large")
-					ctx.SetVariable("branch_type", "large")
+					ctx.Set("branch_type", "large")
 					return "large processed", nil
 				}))
 		reg2.MustRegister(ActivityFunc("final_activity", func(ctx Context, params map[string]any) (any, error) {
@@ -1145,42 +1150,42 @@ func TestBranchBranching(t *testing.T) {
 				}))
 		reg5.MustRegister(ActivityFunc("modify_state_alpha", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we start with the setup value
-					counter, ok := ctx.GetVariable("shared_counter")
+					counter, ok := ctx.Get("shared_counter")
 					require.True(t, ok)
 					require.Equal(t, 100, counter)
 
 					// Each branch modifies the same variable name with different values
-					ctx.SetVariable("shared_counter", 200)
-					ctx.SetVariable("path_identifier", "ALPHA")
-					ctx.SetVariable("multiplier", 2)
+					ctx.Set("shared_counter", 200)
+					ctx.Set("path_identifier", "ALPHA")
+					ctx.Set("multiplier", 2)
 
 					recordBranchExecution("alpha")
 					return "alpha-200", nil
 				}))
 		reg5.MustRegister(ActivityFunc("modify_state_beta", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we start with the setup value (not alpha's modification)
-					counter, ok := ctx.GetVariable("shared_counter")
+					counter, ok := ctx.Get("shared_counter")
 					require.True(t, ok)
 					require.Equal(t, 100, counter)
 
 					// Each branch modifies the same variable name with different values
-					ctx.SetVariable("shared_counter", 300)
-					ctx.SetVariable("path_identifier", "BETA")
-					ctx.SetVariable("multiplier", 3)
+					ctx.Set("shared_counter", 300)
+					ctx.Set("path_identifier", "BETA")
+					ctx.Set("multiplier", 3)
 
 					recordBranchExecution("beta")
 					return "beta-300", nil
 				}))
 		reg5.MustRegister(ActivityFunc("modify_state_gamma", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we start with the setup value (not alpha's or beta's modifications)
-					counter, ok := ctx.GetVariable("shared_counter")
+					counter, ok := ctx.Get("shared_counter")
 					require.True(t, ok)
 					require.Equal(t, 100, counter)
 
 					// Each branch modifies the same variable name with different values
-					ctx.SetVariable("shared_counter", 400)
-					ctx.SetVariable("path_identifier", "GAMMA")
-					ctx.SetVariable("multiplier", 4)
+					ctx.Set("shared_counter", 400)
+					ctx.Set("path_identifier", "GAMMA")
+					ctx.Set("multiplier", 4)
 
 					recordBranchExecution("gamma")
 					return "gamma-400", nil
@@ -1473,18 +1478,18 @@ func TestNamedBranches(t *testing.T) {
 				}))
 		reg5.MustRegister(ActivityFunc("continue_activity", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we can see the previous step's result (proving branch continuity)
-					step1Result, exists := ctx.GetVariable("step1_result")
+					step1Result, exists := ctx.Get("step1_result")
 					require.True(t, exists)
 					require.Equal(t, "step1_done", step1Result)
 					return "step2_done", nil
 				}))
 		reg5.MustRegister(ActivityFunc("final_activity", func(ctx Context, params map[string]any) (any, error) {
 					// Verify we can see both previous steps' results
-					step1Result, exists := ctx.GetVariable("step1_result")
+					step1Result, exists := ctx.Get("step1_result")
 					require.True(t, exists)
 					require.Equal(t, "step1_done", step1Result)
 
-					step2Result, exists := ctx.GetVariable("step2_result")
+					step2Result, exists := ctx.Get("step2_result")
 					require.True(t, exists)
 					require.Equal(t, "step2_done", step2Result)
 

--- a/production_readiness_test.go
+++ b/production_readiness_test.go
@@ -30,17 +30,17 @@ func TestMultiWaitWithRecordOrReplay(t *testing.T) {
 	var invocations int32
 	multiWait := ActivityFunc("multi", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
-		history := ActivityHistory(ctx)
+		history := ctx.History()
 
 		v1, err := history.RecordOrReplay("wait1", func() (any, error) {
-			return Wait(ctx, topic1, time.Minute)
+			return ctx.Wait(topic1, time.Minute)
 		})
 		if err != nil {
 			return nil, err
 		}
 
 		v2, err := history.RecordOrReplay("wait2", func() (any, error) {
-			return Wait(ctx, topic2, time.Minute)
+			return ctx.Wait(topic2, time.Minute)
 		})
 		if err != nil {
 			return nil, err
@@ -130,7 +130,7 @@ func TestPauseDuringActiveWait(t *testing.T) {
 		atomic.AddInt32(&invocations, 1)
 		// Wait for the test to call PauseBranch, then unwind via Wait.
 		<-gate
-		return Wait(ctx, "topic", time.Minute)
+		return ctx.Wait("topic", time.Minute)
 	})
 
 	wf, err := New(Options{
@@ -203,7 +203,7 @@ func TestPauseFreezesSignalWaitDeadline(t *testing.T) {
 	const timeout = 100 * time.Millisecond
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
-		return Wait(ctx, topic, timeout)
+		return ctx.Wait(topic, timeout)
 	})
 
 	wf, err := New(Options{
@@ -308,8 +308,8 @@ func TestConcurrentSignalDeliveryStress(t *testing.T) {
 
 	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 	waiter := ActivityFunc("waiter", func(ctx Context, p map[string]any) (any, error) {
-		topic := fmt.Sprintf("topic-%s", ctx.GetBranchID())
-		return Wait(ctx, topic, time.Minute)
+		topic := fmt.Sprintf("topic-%s", ctx.BranchID())
+		return ctx.Wait(topic, time.Minute)
 	})
 
 	wf, err := New(Options{Name: "concurrent-signals", Steps: steps})
@@ -477,7 +477,7 @@ func TestResumeFromCheckpointMultipleSignalWaitsInSameExecution(t *testing.T) {
 	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		// Topic embeds the branch ID so each branch waits on its own.
-		return Wait(ctx, fmt.Sprintf("t-%s", ctx.GetBranchID()), time.Minute)
+		return ctx.Wait(fmt.Sprintf("t-%s", ctx.BranchID()), time.Minute)
 	})
 
 	wf, err := New(Options{
@@ -599,10 +599,10 @@ func TestRecordOrReplayWrappingWaitCachesValueOnSuccess(t *testing.T) {
 	var fnCalls int32
 
 	wrapped := ActivityFunc("wrapped", func(ctx Context, p map[string]any) (any, error) {
-		history := ActivityHistory(ctx)
+		history := ctx.History()
 		return history.RecordOrReplay("wait", func() (any, error) {
 			atomic.AddInt32(&fnCalls, 1)
-			return Wait(ctx, topic, time.Minute)
+			return ctx.Wait(topic, time.Minute)
 		})
 	})
 

--- a/progress.go
+++ b/progress.go
@@ -6,29 +6,8 @@ type ProgressDetail struct {
 	// Message is a human-readable description of the current progress.
 	Message string
 
-	// Data is arbitrary structured data that consumers can use to drive
-	// UIs, metrics, or logging. The library does not inspect it.
+	// Data is arbitrary structured data that consumers can use to
+	// drive UIs, metrics, or logging. The library does not inspect
+	// it.
 	Data map[string]any
-}
-
-// ProgressReporter is an optional interface that workflow contexts may
-// implement to support intra-activity progress reporting.
-type ProgressReporter interface {
-	ReportProgress(detail ProgressDetail)
-}
-
-// ReportProgress reports intra-activity progress. If the context supports
-// progress reporting (i.e., a StepProgressStore is configured), the detail
-// is forwarded to the store. Otherwise this is a no-op.
-//
-// Example:
-//
-//	workflow.ReportProgress(ctx, workflow.ProgressDetail{
-//	    Message: "Processing batch 3 of 12",
-//	    Data:    map[string]any{"batch": 3, "total": 12},
-//	})
-func ReportProgress(ctx Context, detail ProgressDetail) {
-	if pr, ok := ctx.(ProgressReporter); ok {
-		pr.ReportProgress(detail)
-	}
 }

--- a/runner_suspension_test.go
+++ b/runner_suspension_test.go
@@ -27,7 +27,7 @@ func TestRunnerSurfacesSuspendedResult(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
-		return Wait(ctx, topic, time.Minute)
+		return ctx.Wait(topic, time.Minute)
 	})
 
 	reg := NewActivityRegistry()
@@ -101,7 +101,7 @@ func TestRunnerDoesNotRunCompletionHookOnSuspension(t *testing.T) {
 
 	signals := NewMemorySignalStore()
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
-		return Wait(ctx, topic, time.Minute)
+		return ctx.Wait(topic, time.Minute)
 	})
 
 	reg := NewActivityRegistry()
@@ -144,7 +144,7 @@ func TestRunnerResumeAfterSignalCompletes(t *testing.T) {
 	signals := NewMemorySignalStore()
 	cp := newSpikeMemoryCheckpointer()
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
-		return Wait(ctx, topic, time.Minute)
+		return ctx.Wait(topic, time.Minute)
 	})
 
 	reg := NewActivityRegistry()

--- a/step_progress.go
+++ b/step_progress.go
@@ -36,7 +36,7 @@ type StepProgress struct {
 	Attempt int
 
 	// Detail is optional progress information set by activities via
-	// workflow.ReportProgress(). Nil unless the activity reports intra-step
+	// Context.ReportProgress. Nil unless the activity reports intra-step
 	// progress.
 	Detail *ProgressDetail
 

--- a/step_progress_test.go
+++ b/step_progress_test.go
@@ -100,7 +100,7 @@ func TestStepProgressReportProgressDetail(t *testing.T) {
 
 	reg := NewActivityRegistry()
 	reg.MustRegister(ActivityFunc("slow", func(ctx Context, params map[string]any) (any, error) {
-				ReportProgress(ctx, ProgressDetail{
+				ctx.ReportProgress(ProgressDetail{
 					Message: "Halfway there",
 					Data:    map[string]any{"pct": 50},
 				})
@@ -140,7 +140,7 @@ func TestReportProgressNoopWithoutStore(t *testing.T) {
 	reg := NewActivityRegistry()
 	reg.MustRegister(ActivityFunc("work", func(ctx Context, params map[string]any) (any, error) {
 				// Should not panic even without a store
-				ReportProgress(ctx, ProgressDetail{Message: "hello"})
+				ctx.ReportProgress(ProgressDetail{Message: "hello"})
 				return nil, nil
 			}))
 	exec, err := NewExecution(wf, reg,

--- a/variable_container.go
+++ b/variable_container.go
@@ -4,22 +4,6 @@ import (
 	"reflect"
 )
 
-// VariableContainer is a container for state variables.
-type VariableContainer interface {
-
-	// SetVariable sets the value of a state variable.
-	SetVariable(key string, value any)
-
-	// DeleteVariable deletes a state variable.
-	DeleteVariable(key string)
-
-	// ListVariables returns a slice containing all variable names.
-	ListVariables() []string
-
-	// GetVariable returns the value of a state variable.
-	GetVariable(key string) (value any, exists bool)
-}
-
 // patchOptions is used to create a patch.
 type patchOptions struct {
 	Variable string
@@ -34,17 +18,9 @@ type patch struct {
 	delete   bool
 }
 
-func (p patch) Variable() string {
-	return p.variable
-}
-
-func (p patch) Value() any {
-	return p.value
-}
-
-func (p patch) Delete() bool {
-	return p.delete
-}
+func (p patch) Variable() string { return p.variable }
+func (p patch) Value() any       { return p.value }
+func (p patch) Delete() bool     { return p.delete }
 
 // newPatch creates a new patch.
 func newPatch(opts patchOptions) patch {
@@ -55,48 +31,34 @@ func newPatch(opts patchOptions) patch {
 	}
 }
 
-// generatePatches compares original and modified state maps and returns patches
-// for the differences.
+// generatePatches compares original and modified state maps and
+// returns patches for the differences.
 func generatePatches(original, modified map[string]any) []patch {
 	var patches []patch
-	// Check for modified or added variables
 	for key, currentValue := range modified {
 		if originalValue, exists := original[key]; exists {
-			// Variable existed before - check if it was modified
 			if !reflect.DeepEqual(originalValue, currentValue) {
-				patches = append(patches, patch{
-					variable: key,
-					value:    currentValue,
-				})
+				patches = append(patches, patch{variable: key, value: currentValue})
 			}
 		} else {
-			// New variable added
-			patches = append(patches, patch{
-				variable: key,
-				value:    currentValue,
-			})
+			patches = append(patches, patch{variable: key, value: currentValue})
 		}
 	}
-	// Check for deleted variables
 	for key := range original {
 		if _, exists := modified[key]; !exists {
-			// Variable was deleted
-			patches = append(patches, patch{
-				variable: key,
-				delete:   true,
-			})
+			patches = append(patches, patch{variable: key, delete: true})
 		}
 	}
 	return patches
 }
 
-// applyPatches applies a list of patches to a variable container.
-func applyPatches(container VariableContainer, patches []patch) {
-	for _, patch := range patches {
-		if patch.delete {
-			container.DeleteVariable(patch.variable)
+// applyPatches applies a list of patches to a branch-local state map.
+func applyPatches(state *BranchLocalState, patches []patch) {
+	for _, p := range patches {
+		if p.delete {
+			state.Delete(p.variable)
 		} else {
-			container.SetVariable(patch.variable, patch.value)
+			state.Set(p.variable, p.value)
 		}
 	}
 }

--- a/wait.go
+++ b/wait.go
@@ -6,22 +6,23 @@ import (
 	"time"
 )
 
-// ErrWaitTimeout is returned from workflow.Wait when the wait's deadline
-// has passed and no signal was delivered. Catch handlers can match on
-// ErrorTypeTimeout to route timeouts to a recovery step.
+// ErrWaitTimeout is returned from Context.Wait when the wait's
+// deadline has passed and no signal was delivered. Catch handlers
+// can match on ErrorTypeTimeout to route timeouts to a recovery step.
 var ErrWaitTimeout = errors.New("workflow: wait timed out")
 
-// waitUnwindError is a sentinel returned from workflow.Wait (and from the
-// declarative WaitSignal step handler) when no signal is pending. The
-// branch execution layer intercepts it, sends a waitRequest snapshot, and
-// the orchestrator persists the Wait state before hard-suspending. On
-// resume, the activity re-runs from its entry point; the second call to
-// workflow.Wait finds the signal in the store and returns the payload.
+// waitUnwindError is the sentinel returned from Context.Wait (and from
+// the declarative WaitSignal step handler) when no signal is pending.
+// The branch execution layer intercepts it, sends a waitRequest
+// snapshot, and the orchestrator persists the Wait state before
+// hard-suspending. On resume, the activity re-runs from its entry
+// point; the second call to Wait finds the signal in the store and
+// returns the payload.
 //
-// waitUnwindError bypasses retry and catch handlers (see MatchesErrorType
-// and executeStepWithRetry / executeCatchHandler). A wait-unwind is not a
-// failure — it's a suspension — so it must never consume retry budget or
-// trigger a catch route.
+// waitUnwindError bypasses retry and catch handlers (see
+// MatchesErrorType and executeStepWithRetry / executeCatchHandler).
+// A wait-unwind is not a failure — it's a suspension — so it must
+// never consume retry budget or trigger a catch route.
 type waitUnwindError struct {
 	Wait *WaitState
 }
@@ -48,100 +49,70 @@ func isWaitUnwind(err error) bool {
 	return ok
 }
 
-// SignalAware is the side interface that lets activity code reach the
-// signal infrastructure without depending on the concrete
-// *executionContext type. workflow.Wait calls into this rather than
-// type-asserting against the private context, so consumers can wrap or
-// decorate workflow.Context without breaking waits.
-//
-// The library's executionContext is the only built-in implementation.
-// Tests and middleware that want to forward Wait to a real execution can
-// embed or delegate to it.
-type SignalAware interface {
-	SignalStore() SignalStore
-	ExecutionID() string
-	// PendingWait returns the wait state the branch was parked on before
-	// the current activity invocation, if any. It is non-nil when the
-	// activity is being replayed after a resume from a hard-suspended
-	// checkpoint, so workflow.Wait can reuse the original deadline
-	// rather than starting the clock over.
-	PendingWait() *WaitState
-}
-
-// Wait durably waits for a signal on the given topic. Call from activity
-// code via a workflow.Context that implements [SignalAware] (the
-// execution-provided context does).
+// Wait durably waits for a signal on the given topic. See Context.Wait
+// for the replay-safety contract and the multi-wait pattern.
 //
 // Behavior:
 //   - If a signal is already pending in the SignalStore, returns its
 //     payload immediately.
 //   - If the branch is being replayed after a resume and the original
-//     deadline has passed, returns [ErrWaitTimeout].
+//     deadline has passed, returns ErrWaitTimeout.
 //   - Otherwise returns a sentinel error that unwinds the activity,
-//     causing the branch to checkpoint and the execution to suspend with
-//     status ExecutionStatusSuspended. On resume, the entire activity
-//     re-executes from its entry point; the second call to Wait either
-//     finds the signal, returns ErrWaitTimeout, or unwinds again.
+//     causing the branch to checkpoint and the execution to suspend
+//     with status ExecutionStatusSuspended. On resume, the entire
+//     activity re-executes from its entry point; the second call to
+//     Wait either finds the signal, returns ErrWaitTimeout, or
+//     unwinds again.
 //
-// The replay-safety contract — what is and is not guaranteed safe across
-// replays — is documented in §9 of planning/prds/002-signals-waits-pausing.md
-// ("Replay-safety contract (authoritative)"). Any code that runs before
-// a Wait call may execute more than once. Wrap non-idempotent work in
-// [ActivityHistory] or use idempotency keys.
+// The replay-safety contract — what is and is not guaranteed safe
+// across replays — is documented in §9 of
+// planning/prds/002-signals-waits-pausing.md ("Replay-safety contract
+// (authoritative)"). Any code that runs before a Wait call may
+// execute more than once. Wrap non-idempotent work in the History
+// cache returned by Context.History or use idempotency keys.
 //
 // Multiple waits in one activity. An activity may call Wait more than
-// once (e.g. an agent loop that calls one tool, waits for the response,
-// calls another tool, waits again). Each Wait MUST be wrapped in
-// [History.RecordOrReplay] so the result of an earlier wait is cached
-// across replays. Without the wrapper, a second-wait suspension causes
-// the activity to replay from the top, which re-calls the first Wait
-// against an empty SignalStore — the first signal has already been
-// consumed and is gone. The result is undefined: the first Wait will
-// re-suspend, or worse, consume a signal intended for a different wait.
+// once. Each Wait MUST be wrapped in History.RecordOrReplay so the
+// result of an earlier wait is cached across replays. Without the
+// wrapper, a second-wait suspension causes the activity to replay
+// from the top, which re-calls the first Wait against an empty
+// SignalStore — the first signal has already been consumed and is
+// gone.
 //
-// Correct multi-wait pattern:
-//
-//	history := workflow.ActivityHistory(ctx)
-//	v1, err := history.RecordOrReplay("wait1", func() (any, error) {
-//	    return workflow.Wait(ctx, topic1, time.Hour)
+//	h := ctx.History()
+//	v1, err := h.RecordOrReplay("wait1", func() (any, error) {
+//	    return ctx.Wait(topic1, time.Hour)
 //	})
 //	if err != nil { return nil, err }
-//	v2, err := history.RecordOrReplay("wait2", func() (any, error) {
-//	    return workflow.Wait(ctx, topic2, time.Hour)
+//	v2, err := h.RecordOrReplay("wait2", func() (any, error) {
+//	    return ctx.Wait(topic2, time.Hour)
 //	})
-func Wait(ctx Context, topic string, timeout time.Duration) (any, error) {
-	// Respect context cancellation — an already-done context should
-	// surface its error rather than silently unwind.
-	if err := ctx.Err(); err != nil {
+func (w *executionContext) Wait(topic string, timeout time.Duration) (any, error) {
+	if err := w.Err(); err != nil {
 		return nil, err
 	}
-	sa, ok := ctx.(SignalAware)
-	if !ok {
-		return nil, fmt.Errorf("workflow.Wait: context is not signal-aware (no SignalStore plumbing)")
+	if w.signalStore == nil {
+		return nil, fmt.Errorf("workflow: Context.Wait: no SignalStore configured on execution")
 	}
-	store := sa.SignalStore()
-	if store == nil {
-		return nil, fmt.Errorf("workflow.Wait: no SignalStore configured on execution")
-	}
-	executionID := sa.ExecutionID()
+	store := w.signalStore
+	executionID := w.executionID
 
-	// First, always consult the store so "signal already present" wins
-	// and replayed calls after delivery return immediately.
-	sig, err := store.Receive(ctx, executionID, topic)
+	// Consult the store first so "signal already present" wins and
+	// replayed calls after delivery return immediately.
+	sig, err := store.Receive(w, executionID, topic)
 	if err != nil {
-		return nil, fmt.Errorf("workflow.Wait: receive failed: %w", err)
+		return nil, fmt.Errorf("workflow: Context.Wait: receive failed: %w", err)
 	}
 	if sig != nil {
 		return sig.Payload, nil
 	}
 
-	// Build / reuse the wait state. On a replay after resume the branch
-	// already has a WaitState on its checkpoint with the original
-	// deadline; reuse it so the clock doesn't restart.
-	pending := sa.PendingWait()
+	// Build / reuse the wait state. On a replay after resume the
+	// branch already has a WaitState on its checkpoint with the
+	// original deadline; reuse it so the clock doesn't restart.
+	pending := w.pendingWait
 	var ws *WaitState
 	if pending != nil && pending.Kind == WaitKindSignal && pending.Topic == topic {
-		// Reuse so the absolute deadline is preserved.
 		reused := *pending
 		ws = &reused
 	} else {

--- a/wait_test.go
+++ b/wait_test.go
@@ -39,7 +39,7 @@ func TestWaitSpike(t *testing.T) {
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
-		reply, err := Wait(ctx, topic, time.Minute)
+		reply, err := ctx.Wait(topic, time.Minute)
 		if err != nil {
 			return nil, err
 		}
@@ -136,7 +136,7 @@ func TestWaitSignalAlreadyPresent(t *testing.T) {
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
-		return Wait(ctx, topic, time.Minute)
+		return ctx.Wait(topic, time.Minute)
 	})
 
 	reg := NewActivityRegistry()
@@ -181,7 +181,7 @@ func TestWaitImperativeTimeoutNoCatch(t *testing.T) {
 	cp := newSpikeMemoryCheckpointer()
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
-		return Wait(ctx, topic, 10*time.Millisecond)
+		return ctx.Wait(topic, 10*time.Millisecond)
 	})
 
 	reg := NewActivityRegistry()
@@ -251,7 +251,7 @@ func TestWaitImperativeTimeoutWithCatch(t *testing.T) {
 	cp := newSpikeMemoryCheckpointer()
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
-		return Wait(ctx, topic, 10*time.Millisecond)
+		return ctx.Wait(topic, 10*time.Millisecond)
 	})
 	recoverer := ActivityFunc("recoverer", func(ctx Context, params map[string]any) (any, error) {
 		return "recovered", nil
@@ -307,7 +307,7 @@ func TestWaitCancelDuringWait(t *testing.T) {
 	signals := NewMemorySignalStore()
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, params map[string]any) (any, error) {
-		return Wait(ctx, "any", time.Minute)
+		return ctx.Wait("any", time.Minute)
 	})
 
 	reg := NewActivityRegistry()
@@ -496,7 +496,7 @@ func TestWaitMultiBranch(t *testing.T) {
 
 	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) { return "ok", nil })
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
-		return Wait(ctx, topic, time.Minute)
+		return ctx.Wait(topic, time.Minute)
 	})
 
 	reg := NewActivityRegistry()
@@ -551,7 +551,7 @@ func TestWaitRetryBypass(t *testing.T) {
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&invocations, 1)
-		return Wait(ctx, "no-signal", time.Minute)
+		return ctx.Wait("no-signal", time.Minute)
 	})
 
 	reg := NewActivityRegistry()
@@ -596,7 +596,7 @@ func TestWaitCatchBypass(t *testing.T) {
 	signals := NewMemorySignalStore()
 
 	awaiter := ActivityFunc("awaiter", func(ctx Context, p map[string]any) (any, error) {
-		return Wait(ctx, "nope", time.Minute)
+		return ctx.Wait("nope", time.Minute)
 	})
 	noop := ActivityFunc("noop", func(ctx Context, p map[string]any) (any, error) {
 		atomic.AddInt32(&handleCalled, 1)

--- a/workflowtest/fake_context.go
+++ b/workflowtest/fake_context.go
@@ -1,0 +1,170 @@
+package workflowtest
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/deepnoodle-ai/workflow"
+	"github.com/deepnoodle-ai/workflow/script"
+)
+
+// FakeContextOptions configures a FakeContext. Every field is
+// optional; any field left zero gets a sensible default so test code
+// can construct a FakeContext with {} and still have a usable Context.
+type FakeContextOptions struct {
+	// Inputs is the initial workflow inputs.
+	Inputs map[string]any
+	// Variables is the initial branch-local state.
+	Variables map[string]any
+	// Logger overrides the default discard logger.
+	Logger *slog.Logger
+	// Compiler overrides the default compiler. When nil, callers of
+	// Compiler() receive nil — tests that exercise template
+	// evaluation should always set this.
+	Compiler script.Compiler
+	// BranchID is the value returned by Context.BranchID. Defaults
+	// to "fake-branch".
+	BranchID string
+	// StepName is the value returned by Context.StepName. Defaults
+	// to "fake-step".
+	StepName string
+	// WaitFunc, when non-nil, is invoked by Context.Wait. Tests that
+	// exercise wait semantics supply their own function; otherwise
+	// Wait returns (nil, nil).
+	WaitFunc func(topic string, timeout time.Duration) (any, error)
+	// OnProgress, when non-nil, receives every ProgressDetail passed
+	// to Context.ReportProgress. Tests can inspect the slice to
+	// verify their activity reported progress correctly.
+	OnProgress func(detail workflow.ProgressDetail)
+}
+
+// FakeContext is a workflow.Context implementation for consumer tests
+// that want to unit-test activity code without constructing a full
+// Execution. It is concurrent-safe and exposes the same surface as
+// the engine-backed context.
+type FakeContext struct {
+	ctx        context.Context
+	mu         sync.RWMutex
+	inputs     map[string]any
+	variables  map[string]any
+	logger     *slog.Logger
+	compiler   script.Compiler
+	branchID   string
+	stepName   string
+	history    *workflow.History
+	waitFunc   func(topic string, timeout time.Duration) (any, error)
+	onProgress func(detail workflow.ProgressDetail)
+}
+
+// NewFakeContext builds a FakeContext from the given options. The
+// returned FakeContext satisfies workflow.Context.
+func NewFakeContext(opts FakeContextOptions) *FakeContext {
+	inputs := make(map[string]any, len(opts.Inputs))
+	for k, v := range opts.Inputs {
+		inputs[k] = v
+	}
+	vars := make(map[string]any, len(opts.Variables))
+	for k, v := range opts.Variables {
+		vars[k] = v
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	branchID := opts.BranchID
+	if branchID == "" {
+		branchID = "fake-branch"
+	}
+	stepName := opts.StepName
+	if stepName == "" {
+		stepName = "fake-step"
+	}
+	return &FakeContext{
+		ctx:        context.Background(),
+		inputs:     inputs,
+		variables:  vars,
+		logger:     logger,
+		compiler:   opts.Compiler,
+		branchID:   branchID,
+		stepName:   stepName,
+		history:    workflow.NewHistoryForTest(),
+		waitFunc:   opts.WaitFunc,
+		onProgress: opts.OnProgress,
+	}
+}
+
+// ---- context.Context ----
+
+func (f *FakeContext) Deadline() (time.Time, bool) { return f.ctx.Deadline() }
+func (f *FakeContext) Done() <-chan struct{}       { return f.ctx.Done() }
+func (f *FakeContext) Err() error                  { return f.ctx.Err() }
+func (f *FakeContext) Value(key any) any           { return f.ctx.Value(key) }
+
+// ---- workflow.Context ----
+
+func (f *FakeContext) Inputs() workflow.Inputs {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	out := make(map[string]any, len(f.inputs))
+	for k, v := range f.inputs {
+		out[k] = v
+	}
+	return workflow.NewInputsForTest(out)
+}
+
+func (f *FakeContext) Set(key string, value any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.variables[key] = value
+}
+
+func (f *FakeContext) Get(key string) (any, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	v, ok := f.variables[key]
+	return v, ok
+}
+
+func (f *FakeContext) Delete(key string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.variables, key)
+}
+
+func (f *FakeContext) Keys() []string {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	keys := make([]string, 0, len(f.variables))
+	for k := range f.variables {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func (f *FakeContext) Logger() *slog.Logger       { return f.logger }
+func (f *FakeContext) Compiler() script.Compiler  { return f.compiler }
+func (f *FakeContext) BranchID() string           { return f.branchID }
+func (f *FakeContext) StepName() string           { return f.stepName }
+func (f *FakeContext) History() *workflow.History { return f.history }
+
+func (f *FakeContext) Wait(topic string, timeout time.Duration) (any, error) {
+	if f.waitFunc != nil {
+		return f.waitFunc(topic, timeout)
+	}
+	return nil, nil
+}
+
+func (f *FakeContext) ReportProgress(detail workflow.ProgressDetail) {
+	if f.onProgress != nil {
+		f.onProgress(detail)
+	}
+}
+
+// SetContext replaces the underlying context.Context. Useful for
+// tests that need to exercise cancellation or deadlines.
+func (f *FakeContext) SetContext(ctx context.Context) { f.ctx = ctx }

--- a/workflowtest/fake_context_test.go
+++ b/workflowtest/fake_context_test.go
@@ -1,0 +1,77 @@
+package workflowtest_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/deepnoodle-ai/workflow"
+	"github.com/deepnoodle-ai/workflow/internal/require"
+	"github.com/deepnoodle-ai/workflow/workflowtest"
+)
+
+func TestFakeContext_Defaults(t *testing.T) {
+	var _ workflow.Context = (*workflowtest.FakeContext)(nil)
+
+	fc := workflowtest.NewFakeContext(workflowtest.FakeContextOptions{})
+	require.Equal(t, "fake-branch", fc.BranchID())
+	require.Equal(t, "fake-step", fc.StepName())
+	require.NotNil(t, fc.Logger())
+	require.NotNil(t, fc.History())
+	require.Equal(t, 0, fc.Inputs().Len())
+}
+
+func TestFakeContext_VariablesAndInputs(t *testing.T) {
+	fc := workflowtest.NewFakeContext(workflowtest.FakeContextOptions{
+		Inputs:    map[string]any{"name": "alice"},
+		Variables: map[string]any{"counter": 1},
+	})
+
+	name, ok := fc.Inputs().Get("name")
+	require.True(t, ok)
+	require.Equal(t, "alice", name)
+
+	counter, ok := fc.Get("counter")
+	require.True(t, ok)
+	require.Equal(t, 1, counter)
+
+	fc.Set("counter", 2)
+	counter, _ = fc.Get("counter")
+	require.Equal(t, 2, counter)
+
+	fc.Set("other", "x")
+	require.Equal(t, []string{"counter", "other"}, fc.Keys())
+
+	fc.Delete("other")
+	_, ok = fc.Get("other")
+	require.False(t, ok)
+}
+
+func TestFakeContext_Wait(t *testing.T) {
+	boom := errors.New("boom")
+	fc := workflowtest.NewFakeContext(workflowtest.FakeContextOptions{
+		WaitFunc: func(topic string, timeout time.Duration) (any, error) {
+			require.Equal(t, "approve", topic)
+			return nil, boom
+		},
+	})
+
+	_, err := fc.Wait("approve", time.Second)
+	require.True(t, errors.Is(err, boom))
+}
+
+func TestFakeContext_ReportProgress(t *testing.T) {
+	var reports []workflow.ProgressDetail
+	fc := workflowtest.NewFakeContext(workflowtest.FakeContextOptions{
+		OnProgress: func(d workflow.ProgressDetail) {
+			reports = append(reports, d)
+		},
+	})
+
+	fc.ReportProgress(workflow.ProgressDetail{Message: "step 1 of 2"})
+	fc.ReportProgress(workflow.ProgressDetail{Message: "step 2 of 2"})
+
+	require.Len(t, reports, 2)
+	require.Equal(t, "step 1 of 2", reports[0].Message)
+	require.Equal(t, "step 2 of 2", reports[1].Message)
+}


### PR DESCRIPTION
## Summary

Folds the side-interfaces (VariableContainer, SignalAware, ActivityHistoryAware, ProgressReporter) into Context and renames the Get*/List* accessors to property-style.

### New Context shape

```go
type Context interface {
    context.Context
    Inputs() Inputs
    Set(key string, value any)
    Get(key string) (any, bool)
    Delete(key string)
    Keys() []string
    Logger() *slog.Logger
    Compiler() script.Compiler
    BranchID() string
    StepName() string
    Wait(topic string, timeout time.Duration) (any, error)
    History() *History
    ReportProgress(detail ProgressDetail)
}
```

### Deletions
- VariableContainer, SignalAware, ActivityHistoryAware, ProgressReporter interfaces
- Package-level workflow.Wait, workflow.ActivityHistory, workflow.ReportProgress
- InputsFromContext, VariablesFromContext

### Additions
- `Inputs` struct with Get/Keys/Len/ToMap
- `workflowtest.FakeContext` + `NewFakeContext(FakeContextOptions)` for consumer unit tests
- `workflow.NewInputsForTest` / `workflow.NewHistoryForTest` helper constructors

## Test plan
- [x] `make test-all`
- [x] New FakeContext tests in workflowtest/fake_context_test.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)