### PR TITLE
PR7: checkpoint stable wire format

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -2,20 +2,102 @@ package workflow
 
 import "time"
 
-// Checkpoint contains a complete snapshot of execution state
+// CheckpointSchemaVersion is the current wire-format version for
+// checkpoints written by this library. It is embedded in every saved
+// Checkpoint so readers can detect and reject incompatible shapes.
+//
+// Version contract:
+//
+//   - v1: Initial stable schema. Locked at v1 release.
+//
+// Consumers that persist checkpoints to their own storage MUST treat
+// SchemaVersion as a forward-compatibility signal: if a loaded
+// checkpoint has a SchemaVersion higher than the library version
+// understands, the load should fail rather than proceed with a
+// potentially wrong interpretation.
+const CheckpointSchemaVersion = 1
+
+// Checkpoint is the serialized snapshot of an execution. It is the
+// single unit of persistence the engine writes and reads when
+// checkpointing, resuming, and inspecting running or dormant
+// executions.
+//
+// Round-trip contract:
+//
+//   - The engine marshals Checkpoint to JSON via encoding/json.
+//   - Consumers may swap a different encoder for storage, but MUST
+//     produce a byte stream that round-trips back through the same
+//     struct with every field preserved.
+//   - SchemaVersion is set on every save by the engine. Readers must
+//     reject any checkpoint whose SchemaVersion is higher than the
+//     library's CheckpointSchemaVersion.
+//
+// The JSON tag on every field is part of the stable format. Adding a
+// field is always safe (zero value on load from an older writer);
+// renaming or removing a field is a schema break.
 type Checkpoint struct {
-	ID           string                 `json:"id"`
-	ExecutionID  string                 `json:"execution_id"`
-	WorkflowName string                 `json:"workflow_name"`
-	Status       string                 `json:"status"`
-	Inputs       map[string]interface{} `json:"inputs"`
-	Outputs      map[string]interface{} `json:"outputs"`
-	Variables    map[string]interface{} `json:"variables"`
-	BranchStates   map[string]*BranchState  `json:"path_states"`
-	JoinStates   map[string]*JoinState  `json:"join_states"`
-	BranchCounter  int                    `json:"path_counter"`
-	Error        string                 `json:"error,omitempty"`
-	StartTime    time.Time              `json:"start_time,omitzero"`
-	EndTime      time.Time              `json:"end_time,omitzero"`
-	CheckpointAt time.Time              `json:"checkpoint_at"`
+	// SchemaVersion is the wire-format version. Set to
+	// CheckpointSchemaVersion by the engine on every save.
+	SchemaVersion int `json:"schema_version"`
+
+	// ID is the unique identifier for this checkpoint snapshot.
+	// Distinct from ExecutionID: a single execution writes many
+	// checkpoints over its lifetime.
+	ID string `json:"id"`
+
+	// ExecutionID is the ID of the execution this checkpoint belongs
+	// to. Stable across all snapshots of the same execution.
+	ExecutionID string `json:"execution_id"`
+
+	// WorkflowName is the name of the workflow definition used to
+	// produce the execution. Informational — the engine does not
+	// consult it on resume.
+	WorkflowName string `json:"workflow_name"`
+
+	// Status is the execution status at the time the checkpoint was
+	// written.
+	Status ExecutionStatus `json:"status"`
+
+	// Inputs is the workflow's input values, as supplied on
+	// NewExecution. Immutable for the lifetime of the execution.
+	Inputs map[string]any `json:"inputs"`
+
+	// Outputs is the declared workflow outputs extracted from the
+	// final branch states when the execution completes. Empty until
+	// then.
+	Outputs map[string]any `json:"outputs"`
+
+	// Variables is the top-level workflow state, distinct from
+	// per-branch state. Used by the orchestrator for shared values
+	// that are not branch-local.
+	Variables map[string]any `json:"variables"`
+
+	// BranchStates holds the per-branch persisted state, keyed by
+	// branch ID. Each entry captures the branch's variables, current
+	// step, retry counters, and any active WaitState.
+	BranchStates map[string]*BranchState `json:"branch_states"`
+
+	// JoinStates holds the persisted state for active join steps,
+	// keyed by join step name.
+	JoinStates map[string]*JoinState `json:"join_states"`
+
+	// BranchCounter is the monotonic counter used to allocate
+	// branch IDs. Persisted so resumed executions continue to
+	// allocate unique IDs.
+	BranchCounter int `json:"branch_counter"`
+
+	// Error is the terminal error message when Status is
+	// ExecutionStatusFailed. Empty otherwise.
+	Error string `json:"error,omitempty"`
+
+	// StartTime is when the execution first began running.
+	StartTime time.Time `json:"start_time,omitzero"`
+
+	// EndTime is when the execution reached a terminal status
+	// (completed, failed, or canceled). Zero for in-flight or
+	// suspended executions.
+	EndTime time.Time `json:"end_time,omitzero"`
+
+	// CheckpointAt is when this snapshot was written.
+	CheckpointAt time.Time `json:"checkpoint_at"`
 }

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -1,0 +1,84 @@
+package workflow_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/deepnoodle-ai/workflow"
+	"github.com/deepnoodle-ai/workflow/internal/require"
+	"github.com/deepnoodle-ai/workflow/workflowtest"
+)
+
+func TestCheckpointSchemaVersionIsSetOnSave(t *testing.T) {
+	cp := workflowtest.NewMemoryCheckpointer()
+	wf, err := workflow.New(workflow.Options{
+		Name:  "schema-test",
+		Steps: []*workflow.Step{{Name: "start", Activity: "noop"}},
+	})
+	require.NoError(t, err)
+
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(workflow.ActivityFunc("noop", func(ctx workflow.Context, params map[string]any) (any, error) {
+		return nil, nil
+	}))
+
+	exec, err := workflow.NewExecution(wf, reg,
+		workflow.WithCheckpointer(cp),
+	)
+	require.NoError(t, err)
+
+	_, err = exec.Execute(context.Background())
+	require.NoError(t, err)
+
+	loaded, err := cp.LoadCheckpoint(context.Background(), exec.ID())
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.Equal(t, workflow.CheckpointSchemaVersion, loaded.SchemaVersion)
+}
+
+func TestCheckpointNewerSchemaVersionIsRejected(t *testing.T) {
+	cp := workflowtest.NewMemoryCheckpointer()
+	err := cp.SaveCheckpoint(context.Background(), &workflow.Checkpoint{
+		SchemaVersion: workflow.CheckpointSchemaVersion + 1,
+		ID:            "cp1",
+		ExecutionID:   "future-exec",
+		WorkflowName:  "test",
+		Status:        workflow.ExecutionStatusRunning,
+	})
+	require.NoError(t, err)
+
+	_, err = cp.LoadCheckpoint(context.Background(), "future-exec")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "newer than supported version")
+}
+
+func TestMemoryCheckpointer_AtomicUpdate(t *testing.T) {
+	cp := workflowtest.NewMemoryCheckpointer()
+
+	initial := &workflow.Checkpoint{
+		SchemaVersion: workflow.CheckpointSchemaVersion,
+		ID:            "cp1",
+		ExecutionID:   "exec",
+		WorkflowName:  "test",
+		Status:        workflow.ExecutionStatusRunning,
+		BranchStates: map[string]*workflow.BranchState{
+			"main": {ID: "main", Status: workflow.ExecutionStatusRunning, CurrentStep: "s1"},
+		},
+	}
+	require.NoError(t, cp.SaveCheckpoint(context.Background(), initial))
+
+	err := cp.AtomicUpdate(context.Background(), "exec", func(c *workflow.Checkpoint) error {
+		c.BranchStates["main"].PauseRequested = true
+		return nil
+	})
+	require.NoError(t, err)
+
+	loaded, err := cp.LoadCheckpoint(context.Background(), "exec")
+	require.NoError(t, err)
+	require.True(t, loaded.BranchStates["main"].PauseRequested)
+}
+
+func TestAtomicCheckpointerInterface(t *testing.T) {
+	var _ workflow.Checkpointer = (*workflowtest.MemoryCheckpointer)(nil)
+	var _ workflow.AtomicCheckpointer = (*workflowtest.MemoryCheckpointer)(nil)
+}

--- a/checkpointer.go
+++ b/checkpointer.go
@@ -4,14 +4,52 @@ import (
 	"context"
 )
 
-// Checkpointer defines simple checkpoint interface
+// Checkpointer is the small interface the engine uses to persist and
+// load execution snapshots. Consumers plug in their own storage
+// (Postgres, Redis, S3, etc.) by implementing these three methods.
+//
+// The built-in FileCheckpointer and MemoryCheckpointer exist for
+// development and testing only; production deployments should
+// provide their own implementation.
 type Checkpointer interface {
-	// SaveCheckpoint saves the current execution state
+	// SaveCheckpoint persists the given checkpoint snapshot. The
+	// engine sets SchemaVersion = CheckpointSchemaVersion on every
+	// call; implementations should record it verbatim.
 	SaveCheckpoint(ctx context.Context, checkpoint *Checkpoint) error
 
-	// LoadCheckpoint loads the latest checkpoint for an execution
+	// LoadCheckpoint returns the most recent checkpoint for the
+	// given execution ID. Returns ErrNoCheckpoint when no
+	// checkpoint exists for the execution. Implementations MUST
+	// reject any loaded checkpoint whose SchemaVersion is greater
+	// than CheckpointSchemaVersion — the library did not write it
+	// and cannot safely interpret it.
 	LoadCheckpoint(ctx context.Context, executionID string) (*Checkpoint, error)
 
-	// DeleteCheckpoint removes checkpoint data for an execution
+	// DeleteCheckpoint removes checkpoint data for an execution.
 	DeleteCheckpoint(ctx context.Context, executionID string) error
+}
+
+// AtomicCheckpointer is an optional side interface a Checkpointer
+// may implement to expose a compare-and-swap style update path. When
+// the engine needs to mutate a checkpoint in-place (e.g.
+// PauseBranchInCheckpoint), it prefers AtomicUpdate over a naive
+// load-modify-write sequence.
+//
+// A Checkpointer that does not implement AtomicCheckpointer still
+// works — the engine falls back to load-modify-write and accepts the
+// race window that implies. Backends with real transactional
+// primitives (Postgres SELECT ... FOR UPDATE, Redis WATCH/MULTI,
+// etcd CAS) should implement this interface to close that window.
+type AtomicCheckpointer interface {
+	// AtomicUpdate loads the checkpoint for the given execution,
+	// runs fn against the loaded copy, and saves the result. The
+	// entire read-modify-write cycle must be atomic with respect to
+	// other writers of the same execution.
+	//
+	// If fn returns an error the checkpoint MUST NOT be saved; the
+	// error is returned verbatim to the caller.
+	//
+	// If no checkpoint exists for the execution ID, AtomicUpdate
+	// returns ErrNoCheckpoint without invoking fn.
+	AtomicUpdate(ctx context.Context, executionID string, fn func(*Checkpoint) error) error
 }

--- a/checkpointer_file.go
+++ b/checkpointer_file.go
@@ -80,6 +80,10 @@ func (c *FileCheckpointer) LoadCheckpoint(ctx context.Context, executionID strin
 	if err := json.Unmarshal(data, &checkpoint); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal checkpoint: %w", err)
 	}
+	if checkpoint.SchemaVersion > CheckpointSchemaVersion {
+		return nil, fmt.Errorf("checkpoint schema version %d is newer than supported version %d",
+			checkpoint.SchemaVersion, CheckpointSchemaVersion)
+	}
 
 	return &checkpoint, nil
 }
@@ -138,7 +142,7 @@ func (c *FileCheckpointer) getExecutionSummary(executionID string) (*ExecutionSu
 	return &ExecutionSummary{
 		ExecutionID:  checkpoint.ExecutionID,
 		WorkflowName: checkpoint.WorkflowName,
-		Status:       checkpoint.Status,
+		Status:       string(checkpoint.Status),
 		StartTime:    checkpoint.StartTime,
 		EndTime:      checkpoint.EndTime,
 		Duration:     c.calculateDuration(checkpoint),

--- a/execution.go
+++ b/execution.go
@@ -376,6 +376,7 @@ func (e *Execution) saveCheckpoint(ctx context.Context) error {
 	e.checkpointCounter++
 	checkpoint := e.state.ToCheckpoint()
 	checkpoint.ID = fmt.Sprintf("%d", e.checkpointCounter)
+	checkpoint.SchemaVersion = CheckpointSchemaVersion
 	return e.checkpointer.SaveCheckpoint(ctx, checkpoint)
 }
 
@@ -394,6 +395,10 @@ func (e *Execution) loadCheckpoint(ctx context.Context, priorExecutionID string)
 	}
 	if checkpoint == nil {
 		return fmt.Errorf("%w: execution %q", ErrNoCheckpoint, priorExecutionID)
+	}
+	if checkpoint.SchemaVersion > CheckpointSchemaVersion {
+		return fmt.Errorf("checkpoint schema version %d is newer than supported version %d",
+			checkpoint.SchemaVersion, CheckpointSchemaVersion)
 	}
 	e.state.FromCheckpoint(checkpoint)
 
@@ -448,7 +453,7 @@ func (e *Execution) loadCheckpoint(ctx context.Context, priorExecutionID string)
 		"status", e.state.GetStatus(),
 		"branches", len(branchStates),
 		"active_paths", e.activeBranchCount(),
-		"path_counter", e.state.pathCounter)
+		"branch_counter", e.state.pathCounter)
 
 	return nil
 }

--- a/execution_state.go
+++ b/execution_state.go
@@ -464,20 +464,21 @@ func (s *executionState) ToCheckpoint() *Checkpoint {
 	defer s.mutex.RUnlock()
 
 	return &Checkpoint{
-		ID:           s.executionID + "-" + fmt.Sprintf("%d", time.Now().UnixNano()),
-		ExecutionID:  s.executionID,
-		WorkflowName: s.workflowName,
-		Status:       string(s.status),
-		Inputs:       copyMap(s.inputs),
-		Outputs:      copyMap(s.outputs),
-		Variables:    map[string]any{}, // Variables are now per-branch, so global variables are empty
-		BranchStates:   copyBranchStates(s.branchStates),
-		JoinStates:   copyJoinStates(s.joinStates),
-		BranchCounter:  s.pathCounter,
-		StartTime:    s.startTime,
-		EndTime:      s.endTime,
-		CheckpointAt: time.Now(),
-		Error:        s.err,
+		SchemaVersion: CheckpointSchemaVersion,
+		ID:            s.executionID + "-" + fmt.Sprintf("%d", time.Now().UnixNano()),
+		ExecutionID:   s.executionID,
+		WorkflowName:  s.workflowName,
+		Status:        s.status,
+		Inputs:        copyMap(s.inputs),
+		Outputs:       copyMap(s.outputs),
+		Variables:     map[string]any{}, // Variables are now per-branch, so global variables are empty
+		BranchStates:  copyBranchStates(s.branchStates),
+		JoinStates:    copyJoinStates(s.joinStates),
+		BranchCounter: s.pathCounter,
+		StartTime:     s.startTime,
+		EndTime:       s.endTime,
+		CheckpointAt:  time.Now(),
+		Error:         s.err,
 	}
 }
 
@@ -488,7 +489,7 @@ func (s *executionState) FromCheckpoint(checkpoint *Checkpoint) {
 
 	s.executionID = checkpoint.ExecutionID
 	s.workflowName = checkpoint.WorkflowName
-	s.status = ExecutionStatus(checkpoint.Status)
+	s.status = checkpoint.Status
 	s.inputs = copyMap(checkpoint.Inputs)
 	s.outputs = copyMap(checkpoint.Outputs)
 	s.branchStates = copyBranchStates(checkpoint.BranchStates)

--- a/execution_test.go
+++ b/execution_test.go
@@ -385,7 +385,7 @@ func TestFileCheckpointerSavesCheckpoints(t *testing.T) {
 		require.NotNil(t, checkpoint)
 		require.Equal(t, execution.ID(), checkpoint.ExecutionID)
 		require.Equal(t, "checkpoint-test-success", checkpoint.WorkflowName)
-		require.Equal(t, "completed", checkpoint.Status)
+		require.Equal(t, ExecutionStatusCompleted, checkpoint.Status)
 	})
 
 	t.Run("failed workflow saves checkpoints", func(t *testing.T) {
@@ -442,7 +442,7 @@ func TestFileCheckpointerSavesCheckpoints(t *testing.T) {
 		require.NotNil(t, checkpoint)
 		require.Equal(t, execution.ID(), checkpoint.ExecutionID)
 		require.Equal(t, "checkpoint-test-failure", checkpoint.WorkflowName)
-		require.Equal(t, "failed", checkpoint.Status)
+		require.Equal(t, ExecutionStatusFailed, checkpoint.Status)
 		require.NotEmpty(t, checkpoint.Error)
 	})
 }
@@ -499,7 +499,7 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		checkpoint, err := checkpointer.LoadCheckpoint(context.Background(), execution1.ID())
 		require.NoError(t, err)
 		require.NotNil(t, checkpoint)
-		require.Equal(t, "failed", checkpoint.Status)
+		require.Equal(t, ExecutionStatusFailed, checkpoint.Status)
 
 		// Create second execution to resume from the first one's checkpoint
 		reg2 := NewActivityRegistry()
@@ -531,7 +531,7 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		finalCheckpoint, err := checkpointer.LoadCheckpoint(context.Background(), execution2.ID())
 		require.NoError(t, err)
 		require.NotNil(t, finalCheckpoint)
-		require.Equal(t, "completed", finalCheckpoint.Status)
+		require.Equal(t, ExecutionStatusCompleted, finalCheckpoint.Status)
 	})
 
 	t.Run("resume completed execution does nothing", func(t *testing.T) {
@@ -571,7 +571,7 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		checkpoint, err := checkpointer.LoadCheckpoint(context.Background(), execution1.ID())
 		require.NoError(t, err)
 		require.NotNil(t, checkpoint)
-		require.Equal(t, "completed", checkpoint.Status)
+		require.Equal(t, ExecutionStatusCompleted, checkpoint.Status)
 
 		// Create second execution to resume from completed one
 		reg4 := NewActivityRegistry()
@@ -701,7 +701,7 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		checkpoint, err := checkpointer.LoadCheckpoint(context.Background(), execution1.ID())
 		require.NoError(t, err)
 		require.NotNil(t, checkpoint)
-		require.Equal(t, "failed", checkpoint.Status)
+		require.Equal(t, ExecutionStatusFailed, checkpoint.Status)
 
 		// Create second execution to resume from the first one's checkpoint
 		reg7 := NewActivityRegistry()
@@ -736,7 +736,7 @@ func TestExecutionResumeFromCheckpoint(t *testing.T) {
 		finalCheckpoint, err := checkpointer.LoadCheckpoint(context.Background(), execution2.ID())
 		require.NoError(t, err)
 		require.NotNil(t, finalCheckpoint)
-		require.Equal(t, "completed", finalCheckpoint.Status)
+		require.Equal(t, ExecutionStatusCompleted, finalCheckpoint.Status)
 	})
 }
 

--- a/pause.go
+++ b/pause.go
@@ -198,6 +198,29 @@ func UnpauseBranchInCheckpoint(ctx context.Context, cp Checkpointer, executionID
 }
 
 func mutatePauseInCheckpoint(ctx context.Context, cp Checkpointer, executionID, branchID string, paused bool, reason string) error {
+	apply := func(checkpoint *Checkpoint) error {
+		ps, ok := checkpoint.BranchStates[branchID]
+		if !ok {
+			return fmt.Errorf("%w: %q (execution %q)", ErrBranchNotFound, branchID, executionID)
+		}
+		ps.PauseRequested = paused
+		ps.PauseReason = reason
+		now := time.Now()
+		if paused {
+			freezeWaitOnPause(ps, now)
+		} else {
+			thawWaitOnUnpause(ps, now)
+		}
+		return nil
+	}
+
+	// Prefer AtomicUpdate when the Checkpointer supports it. Backends
+	// with real transactional primitives close the load-modify-write
+	// race window this function would otherwise open.
+	if ac, ok := cp.(AtomicCheckpointer); ok {
+		return ac.AtomicUpdate(ctx, executionID, apply)
+	}
+
 	checkpoint, err := cp.LoadCheckpoint(ctx, executionID)
 	if err != nil {
 		return fmt.Errorf("loading checkpoint: %w", err)
@@ -205,17 +228,8 @@ func mutatePauseInCheckpoint(ctx context.Context, cp Checkpointer, executionID, 
 	if checkpoint == nil {
 		return fmt.Errorf("%w: execution %q", ErrNoCheckpoint, executionID)
 	}
-	ps, ok := checkpoint.BranchStates[branchID]
-	if !ok {
-		return fmt.Errorf("%w: %q (execution %q)", ErrBranchNotFound, branchID, executionID)
-	}
-	ps.PauseRequested = paused
-	ps.PauseReason = reason
-	now := time.Now()
-	if paused {
-		freezeWaitOnPause(ps, now)
-	} else {
-		thawWaitOnUnpause(ps, now)
+	if err := apply(checkpoint); err != nil {
+		return err
 	}
 	return cp.SaveCheckpoint(ctx, checkpoint)
 }

--- a/pause_test.go
+++ b/pause_test.go
@@ -153,7 +153,7 @@ func TestPauseBranchInCheckpointIdempotent(t *testing.T) {
 		ID:           "cp1",
 		ExecutionID:  execID,
 		WorkflowName: "test",
-		Status:       string(ExecutionStatusRunning),
+		Status:       ExecutionStatusRunning,
 		BranchStates: map[string]*BranchState{
 			"main": {
 				ID:          "main",

--- a/workflowtest/memory_checkpointer.go
+++ b/workflowtest/memory_checkpointer.go
@@ -3,6 +3,7 @@ package workflowtest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/deepnoodle-ai/workflow"
@@ -36,7 +37,29 @@ func (m *MemoryCheckpointer) LoadCheckpoint(ctx context.Context, executionID str
 	if !ok {
 		return nil, nil // Follows existing convention: nil, nil = not found
 	}
+	if cp.SchemaVersion > workflow.CheckpointSchemaVersion {
+		return nil, fmt.Errorf("checkpoint schema version %d is newer than supported version %d",
+			cp.SchemaVersion, workflow.CheckpointSchemaVersion)
+	}
 	return deepCopyCheckpoint(cp), nil
+}
+
+// AtomicUpdate implements workflow.AtomicCheckpointer. The in-memory
+// backend serializes the entire read-modify-write under its write
+// lock.
+func (m *MemoryCheckpointer) AtomicUpdate(ctx context.Context, executionID string, fn func(*workflow.Checkpoint) error) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp, ok := m.checkpoints[executionID]
+	if !ok {
+		return fmt.Errorf("%w: execution %q", workflow.ErrNoCheckpoint, executionID)
+	}
+	working := deepCopyCheckpoint(cp)
+	if err := fn(working); err != nil {
+		return err
+	}
+	m.checkpoints[executionID] = deepCopyCheckpoint(working)
+	return nil
 }
 
 func (m *MemoryCheckpointer) DeleteCheckpoint(ctx context.Context, executionID string) error {

--- a/workflowtest/workflowtest_test.go
+++ b/workflowtest/workflowtest_test.go
@@ -61,7 +61,7 @@ func TestMemoryCheckpointerRoundTrips(t *testing.T) {
 	err := cp.SaveCheckpoint(ctx, &workflow.Checkpoint{
 		ExecutionID:  "exec-1",
 		WorkflowName: "test",
-		Status:       "completed",
+		Status:       workflow.ExecutionStatusCompleted,
 	})
 	require.NoError(t, err)
 
@@ -70,7 +70,7 @@ func TestMemoryCheckpointerRoundTrips(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, loaded)
 	require.Equal(t, "exec-1", loaded.ExecutionID)
-	require.Equal(t, "completed", loaded.Status)
+	require.Equal(t, workflow.ExecutionStatusCompleted, loaded.Status)
 
 	// Load missing
 	missing, err := cp.LoadCheckpoint(ctx, "nonexistent")


### PR DESCRIPTION
## Summary
- Add `CheckpointSchemaVersion` constant and `SchemaVersion` field; readers reject checkpoints newer than the library instead of silently dropping fields.
- Change `Checkpoint.Status` from bare `string` to the `ExecutionStatus` typed constant, and rename the lingering `path_states` / `path_counter` JSON keys to `branch_states` / `branch_counter` to match PR1.
- Add optional `AtomicCheckpointer` side interface for backends with transactional primitives (Postgres row-lock, Redis CAS); `MemoryCheckpointer` implements it, and `PauseBranchInCheckpoint` / `UnpauseBranchInCheckpoint` prefer it when available to close the load-modify-write race.

## Test plan
- [x] `make test-all` passes
- [x] New checkpoint_test.go covers schema version set on save, newer-version rejection, memory AtomicUpdate round-trip, and AtomicCheckpointer interface assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)