### PR TITLE
PR8: single template syntax

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ interfaces for the things it doesn't own. What it does and doesn't do:
 **Does**: Define workflows as step graphs. Execute steps (activities). Branch
 and join execution paths. Retry with backoff. Catch and route errors. Checkpoint
 execution state. Resume from checkpoints. Track step progress. Evaluate edge
-conditions and `${...}` / `$(...)` parameter templates via a bundled
+conditions and `${...}` parameter templates via a bundled
 expression engine (`github.com/deepnoodle-ai/expr`).
 
 **Does not**: Store workflows, checkpoints, or progress. Queue or schedule work.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ checkpointing.
 
 Think of it like a lightweight hybrid of Temporal and AWS Step Functions.
 
-Edge conditions and `${...}` / `$(...)` parameter templates are evaluated
+Edge conditions and `${...}` parameter templates are evaluated
 by [`github.com/deepnoodle-ai/expr`](https://github.com/deepnoodle-ai/expr),
 a small zero-dependency expression evaluator that accepts a Go-like
 subset of expression syntax. It is the only external dependency of the

--- a/branch.go
+++ b/branch.go
@@ -518,7 +518,7 @@ func (p *branch) handleWaitSignalStep(ctx context.Context, step *Step) (any, err
 		// re-evaluation on replay can't drift.
 		resolvedTopic = initial.Topic
 	} else {
-		evaluated, err := p.evaluateTemplate(ctx, cfg.Topic)
+		evaluated, err := p.evaluateTemplateString(ctx, cfg.Topic)
 		if err != nil {
 			return nil, fmt.Errorf("wait_signal step %q: failed to evaluate topic template: %w", step.Name, err)
 		}
@@ -915,9 +915,10 @@ func (p *branch) handleBranching(ctx context.Context) ([]branchSpec, error) {
 	return pathSpecs, nil
 }
 
-// evaluateCondition evaluates a workflow condition
+// evaluateCondition evaluates a workflow condition. Conditions are
+// raw script expressions (e.g. "state.count > 3"). The literal strings
+// "true" and "false" are recognized as shortcuts.
 func (p *branch) evaluateCondition(ctx context.Context, condition string) (bool, error) {
-	// Handle simple boolean conditions
 	switch strings.ToLower(strings.TrimSpace(condition)) {
 	case "true":
 		return true, nil
@@ -925,40 +926,26 @@ func (p *branch) evaluateCondition(ctx context.Context, condition string) (bool,
 		return false, nil
 	}
 
-	// Handle script expressions wrapped in $()
-	codeStr := condition
-	if strings.HasPrefix(codeStr, "$(") && strings.HasSuffix(codeStr, ")") {
-		codeStr = strings.TrimPrefix(codeStr, "$(")
-		codeStr = strings.TrimSuffix(codeStr, ")")
-	}
-
-	// Compile the script
-	compiledScript, err := p.scriptCompiler.Compile(ctx, codeStr)
+	compiledScript, err := p.scriptCompiler.Compile(ctx, condition)
 	if err != nil {
 		return false, fmt.Errorf("failed to compile condition: %w", err)
 	}
-
-	// Evaluate the condition with current state
 	result, err := compiledScript.Evaluate(ctx, p.buildScriptGlobals())
 	if err != nil {
 		return false, fmt.Errorf("failed to evaluate condition: %w", err)
 	}
-
-	// Convert result to boolean
 	return result.IsTruthy(), nil
 }
 
-// evaluateTemplate evaluates a template string
-func (p *branch) evaluateTemplate(ctx context.Context, template string) (string, error) {
-	if strings.HasPrefix(template, "$(") && strings.HasSuffix(template, ")") {
-		template = strings.TrimPrefix(template, "$(")
-		template = strings.TrimSuffix(template, ")")
-	}
+// evaluateTemplateString evaluates a template and always returns a
+// string. Used for signal topic names and other contexts that require
+// a string result.
+func (p *branch) evaluateTemplateString(ctx context.Context, template string) (string, error) {
 	tmpl, err := script.NewTemplate(p.scriptCompiler, template)
 	if err != nil {
 		return "", fmt.Errorf("failed to compile template: %w", err)
 	}
-	return tmpl.Eval(ctx, p.buildScriptGlobals())
+	return tmpl.EvalString(ctx, p.buildScriptGlobals())
 }
 
 // executeStepEach handles the execution of a step that has an each block
@@ -1038,39 +1025,32 @@ func (p *branch) executeStepEach(ctx context.Context, step *Step) (any, error) {
 	return results, nil
 }
 
-// resolveEachItems resolves the array of items from either a direct array or a Risor expression
+// resolveEachItems resolves the array of items for an Each block.
+// A string value is treated as a raw script expression evaluated
+// against the branch globals; array values are returned as-is.
 func (p *branch) resolveEachItems(ctx context.Context, each *Each) ([]any, error) {
-	// Array of strings
 	if strArray, ok := each.Items.([]string); ok {
-		var items []any
+		items := make([]any, 0, len(strArray))
 		for _, item := range strArray {
 			items = append(items, item)
 		}
 		return items, nil
 	}
 
-	// Array of any
 	if items, ok := each.Items.([]any); ok {
 		return items, nil
 	}
 
-	// Handle script expression
 	if codeStr, ok := each.Items.(string); ok {
-		if strings.HasPrefix(codeStr, "$(") {
-			if !strings.HasSuffix(codeStr, ")") {
-				return nil, fmt.Errorf("invalid script expression for 'each' block: %s", codeStr)
-			}
-			return p.evaluateExpression(ctx, codeStr)
-		}
+		return p.evaluateExpression(ctx, codeStr)
 	}
 
-	// Consider it an array of one item
 	return []any{each.Items}, nil
 }
 
-// evaluateExpression evaluates a Risor expression and returns the result as an array
-func (p *branch) evaluateExpression(ctx context.Context, codeStr string) ([]any, error) {
-	code := strings.TrimSuffix(strings.TrimPrefix(codeStr, "$("), ")")
+// evaluateExpression compiles and evaluates a raw script expression,
+// returning its result as a slice.
+func (p *branch) evaluateExpression(ctx context.Context, code string) ([]any, error) {
 	compiledScript, err := p.scriptCompiler.Compile(ctx, code)
 	if err != nil {
 		p.logger.Error("failed to compile 'each' expression", "error", err)
@@ -1213,13 +1193,17 @@ func (p *branch) buildStepParameters(ctx context.Context, step *Step) (map[strin
 	return params, nil
 }
 
-// evaluateParameterValue evaluates a parameter value, handling both script expressions and templates
+// evaluateParameterValue evaluates a parameter value. String values
+// containing ${...} templates are evaluated with contextual type
+// inference: a value that is exactly one ${expr} token (ignoring
+// surrounding whitespace) preserves the expression's typed result;
+// otherwise the result is a string built by interpolating each
+// token's stringified value.
 func (p *branch) evaluateParameterValue(ctx context.Context, value interface{}, stepName, paramName string) (interface{}, error) {
-	// If the parameter is a map, recursively evaluate the values
 	if mapValue, ok := value.(map[string]any); ok {
 		outMap := make(map[string]any, len(mapValue))
-		for key, value := range mapValue {
-			evaluated, err := p.evaluateParameterValue(ctx, value, stepName, key)
+		for key, inner := range mapValue {
+			evaluated, err := p.evaluateParameterValue(ctx, inner, stepName, key)
 			if err != nil {
 				return nil, err
 			}
@@ -1232,40 +1216,19 @@ func (p *branch) evaluateParameterValue(ctx context.Context, value interface{}, 
 	if !ok {
 		return value, nil
 	}
-
-	// Handle script expressions $(code) - these return actual values, not strings
-	if strings.HasPrefix(strValue, "$(") && strings.HasSuffix(strValue, ")") {
-		codeStr := strings.TrimPrefix(strValue, "$(")
-		codeStr = strings.TrimSuffix(codeStr, ")")
-
-		// Compile and evaluate the script
-		compiledScript, err := p.scriptCompiler.Compile(ctx, codeStr)
-		if err != nil {
-			return nil, fmt.Errorf("failed to compile script expression in parameter %q of step %q: %w",
-				paramName, stepName, err)
-		}
-
-		result, err := compiledScript.Evaluate(ctx, p.buildScriptGlobals())
-		if err != nil {
-			return nil, fmt.Errorf("failed to evaluate script expression in parameter %q of step %q: %w",
-				paramName, stepName, err)
-		}
-
-		// Return the actual value from the script
-		return result.Value(), nil
+	if !strings.Contains(strValue, "${") {
+		return value, nil
 	}
 
-	// Handle template strings. Detect if they are present by looking for the
-	// "${" prefix of a template variable.
-	if strings.Contains(strValue, "${") {
-		evaluated, err := p.evaluateTemplate(ctx, strValue)
-		if err != nil {
-			return nil, fmt.Errorf("failed to evaluate parameter template %q in step %q: %w",
-				paramName, stepName, err)
-		}
-		return evaluated, nil
+	tmpl, err := script.NewTemplate(p.scriptCompiler, strValue)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile parameter template %q in step %q: %w",
+			paramName, stepName, err)
 	}
-
-	// Return value as-is
-	return value, nil
+	evaluated, err := tmpl.Eval(ctx, p.buildScriptGlobals())
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate parameter template %q in step %q: %w",
+			paramName, stepName, err)
+	}
+	return evaluated, nil
 }

--- a/branch_test.go
+++ b/branch_test.go
@@ -35,25 +35,25 @@ func TestTemplateParameterEvaluation(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("script expression returns actual value", func(t *testing.T) {
-		result, err := branch.evaluateParameterValue(ctx, "$(state.count * 2)", "test-step", "param")
+	t.Run("single-expression template preserves int type", func(t *testing.T) {
+		result, err := branch.evaluateParameterValue(ctx, "${state.count * 2}", "test-step", "param")
 		require.NoError(t, err)
 		require.EqualValues(t, 84, result)
 	})
 
-	t.Run("script expression returns string", func(t *testing.T) {
-		result, err := branch.evaluateParameterValue(ctx, "$(state.user_name)", "test-step", "param")
+	t.Run("single-expression template returns string value", func(t *testing.T) {
+		result, err := branch.evaluateParameterValue(ctx, "${state.user_name}", "test-step", "param")
 		require.NoError(t, err)
 		require.Equal(t, "Alice", result)
 	})
 
-	t.Run("script expression returns complex value", func(t *testing.T) {
-		result, err := branch.evaluateParameterValue(ctx, "$(state.count)", "test-step", "param")
+	t.Run("single-expression template preserves int", func(t *testing.T) {
+		result, err := branch.evaluateParameterValue(ctx, "${state.count}", "test-step", "param")
 		require.NoError(t, err)
 		require.EqualValues(t, 42, result)
 	})
 
-	t.Run("template string with variable substitution", func(t *testing.T) {
+	t.Run("interpolated template returns concatenated string", func(t *testing.T) {
 		result, err := branch.evaluateParameterValue(ctx, "${inputs.base_url}/users/${state.user_name}", "test-step", "param")
 		require.NoError(t, err)
 		require.Equal(t, "https://api.example.com/users/Alice", result)
@@ -71,16 +71,16 @@ func TestTemplateParameterEvaluation(t *testing.T) {
 		require.Equal(t, true, result)
 	})
 
-	t.Run("malformed script expression returns error", func(t *testing.T) {
-		_, err := branch.evaluateParameterValue(ctx, "$(1 + )", "test-step", "param")
+	t.Run("malformed template expression returns error", func(t *testing.T) {
+		_, err := branch.evaluateParameterValue(ctx, "${1 + }", "test-step", "param")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to compile script expression")
+		require.Contains(t, err.Error(), "failed to compile parameter template")
 	})
 
-	t.Run("undefined variable in script returns error", func(t *testing.T) {
-		_, err := branch.evaluateParameterValue(ctx, "$(state.undefined_var)", "test-step", "param")
+	t.Run("undefined variable in template returns error", func(t *testing.T) {
+		_, err := branch.evaluateParameterValue(ctx, "${state.undefined_var}", "test-step", "param")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to evaluate script expression")
+		require.Contains(t, err.Error(), "failed to evaluate parameter template")
 	})
 }
 
@@ -131,7 +131,7 @@ func TestEachBlockItemResolution(t *testing.T) {
 
 	t.Run("script expression evaluating to array", func(t *testing.T) {
 		each := &Each{
-			Items: "$(state.names)",
+			Items: "state.names",
 		}
 		items, err := branch.resolveEachItems(ctx, each)
 		require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestEachBlockItemResolution(t *testing.T) {
 
 	t.Run("script expression with array literal", func(t *testing.T) {
 		each := &Each{
-			Items: "$([1,2,3])",
+			Items: "[1,2,3]",
 		}
 		items, err := branch.resolveEachItems(ctx, each)
 		require.NoError(t, err)
@@ -152,16 +152,16 @@ func TestEachBlockItemResolution(t *testing.T) {
 
 	t.Run("invalid script expression returns error", func(t *testing.T) {
 		each := &Each{
-			Items: "$(invalid syntax",
+			Items: "invalid ((( syntax",
 		}
 		_, err := branch.resolveEachItems(ctx, each)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid script expression for 'each' block")
+		require.Contains(t, err.Error(), "failed to compile expression")
 	})
 
 	t.Run("single value to iterate over - script expression", func(t *testing.T) {
 		each := &Each{
-			Items: "$(42)", // Returns a number, not an array
+			Items: "42", // Returns a number, not an array
 		}
 		items, err := branch.resolveEachItems(ctx, each)
 		require.NoError(t, err)
@@ -210,31 +210,31 @@ func TestBranchConditionEvaluation(t *testing.T) {
 	})
 
 	t.Run("script expression with state variables", func(t *testing.T) {
-		result, err := branch.evaluateCondition(ctx, "$(state.count > 3)")
+		result, err := branch.evaluateCondition(ctx, "state.count > 3")
 		require.NoError(t, err)
 		require.True(t, result)
 	})
 
 	t.Run("script expression with input variables", func(t *testing.T) {
-		result, err := branch.evaluateCondition(ctx, "$(inputs.threshold < state.count)")
+		result, err := branch.evaluateCondition(ctx, "inputs.threshold < state.count")
 		require.NoError(t, err)
 		require.True(t, result)
 	})
 
 	t.Run("script expression evaluating to false", func(t *testing.T) {
-		result, err := branch.evaluateCondition(ctx, "$(state.count > 10)")
+		result, err := branch.evaluateCondition(ctx, "state.count > 10")
 		require.NoError(t, err)
 		require.False(t, result)
 	})
 
 	t.Run("malformed expression returns error", func(t *testing.T) {
-		_, err := branch.evaluateCondition(ctx, "$(invalid syntax")
+		_, err := branch.evaluateCondition(ctx, "invalid (((( syntax")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to compile condition")
 	})
 
 	t.Run("undefined variable returns error", func(t *testing.T) {
-		_, err := branch.evaluateCondition(ctx, "$(state.undefined_var > 0)")
+		_, err := branch.evaluateCondition(ctx, "state.undefined_var > 0")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to evaluate condition")
 	})
@@ -583,11 +583,11 @@ func TestExecuteStepEach(t *testing.T) {
 			Name:     "test-step",
 			Activity: "test-activity",
 			Each: &Each{
-				Items: "$(state.options)",
+				Items: "state.options",
 				As:    "fruit",
 			},
 			Parameters: map[string]interface{}{
-				"item": "$(state.fruit)",
+				"item": "${state.fruit}",
 			},
 			Store: "the_results",
 		}

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -1198,7 +1198,7 @@ func TestExecution_ScriptExpressionParameters(t *testing.T) {
 				Name:     "compute",
 				Activity: "capture",
 				Parameters: map[string]any{
-					"result": "$(state.count * 10)",
+					"result": "${state.count * 10}",
 				},
 			},
 		},
@@ -1234,7 +1234,7 @@ func TestExecution_EachStep(t *testing.T) {
 				Each:     &Each{Items: []any{1, 2, 3}, As: "item"},
 				Store:    "results",
 				Parameters: map[string]any{
-					"value": "$(state.item)",
+					"value": "${state.item}",
 				},
 			},
 		},

--- a/examples/branching/main.go
+++ b/examples/branching/main.go
@@ -107,7 +107,7 @@ func main() {
 				Name:     "Check Prime",
 				Activity: "check_prime",
 				Parameters: map[string]any{
-					"number": "$(state.random_number)",
+					"number": "${state.random_number}",
 				},
 				Store: "is_prime",
 				Next:  []*workflow.Edge{{Step: "Categorize Number"}},
@@ -116,7 +116,7 @@ func main() {
 				Name:     "Categorize Number",
 				Activity: "categorize_number",
 				Parameters: map[string]any{
-					"number": "$(state.random_number)",
+					"number": "${state.random_number}",
 				},
 				Store: "category",
 				// expr treats state.category as a string once assigned.
@@ -197,7 +197,7 @@ func main() {
 				Name:     "Final Summary",
 				Activity: "label_prime",
 				Parameters: map[string]any{
-					"is_prime": "$(state.is_prime)",
+					"is_prime": "${state.is_prime}",
 				},
 				Store: "prime_label",
 				Next:  []*workflow.Edge{{Step: "Conclusion"}},

--- a/examples/child_workflows/main.go
+++ b/examples/child_workflows/main.go
@@ -243,7 +243,7 @@ func main() {
 				Name:     "Extract Result",
 				Activity: "extract_processed_result",
 				Parameters: map[string]any{
-					"outputs": "$(state.processing_workflow_result.outputs)",
+					"outputs": "${state.processing_workflow_result.outputs}",
 				},
 				Store: "processed_data",
 				Next:  []*workflow.Edge{{Step: "Call Data Validator"}},
@@ -266,7 +266,7 @@ func main() {
 				Name:     "Check Validation",
 				Activity: "extract_validation_result",
 				Parameters: map[string]any{
-					"outputs": "$(state.validation_workflow_result.outputs)",
+					"outputs": "${state.validation_workflow_result.outputs}",
 				},
 				Store: "is_valid",
 				Next: []*workflow.Edge{

--- a/examples/join_branches/README.md
+++ b/examples/join_branches/README.md
@@ -278,8 +278,8 @@ Combine with conditions for complex logic:
         },
     },
     Next: []*workflow.Edge{
-        {Step: "success_step", Condition: "$(results.critical.status == 'success')"},
-        {Step: "failure_step", Condition: "$(results.critical.status != 'success')"},
+        {Step: "success_step", Condition: `results.critical.status == "success"`},
+        {Step: "failure_step", Condition: `results.critical.status != "success"`},
     },
 }
 ```

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -56,7 +56,7 @@ func main() {
 				Name:     "Increment",
 				Activity: "increment",
 				Parameters: map[string]any{
-					"value": "$(state.counter)",
+					"value": "${state.counter}",
 				},
 				Store: "counter",
 				Next:  []*workflow.Edge{{Step: "Wait Then Loop"}},

--- a/examples/structured_result/main.go
+++ b/examples/structured_result/main.go
@@ -48,7 +48,7 @@ func main() {
 				Name:     "Calculate Total",
 				Activity: "calc_total",
 				Parameters: map[string]any{
-					"quantity": "$(inputs.quantity)",
+					"quantity": "${inputs.quantity}",
 				},
 				Store: "total",
 				Next:  []*workflow.Edge{{Step: "Generate Summary"}},
@@ -57,9 +57,9 @@ func main() {
 				Name:     "Generate Summary",
 				Activity: "build_summary",
 				Parameters: map[string]any{
-					"item":     "$(inputs.item)",
-					"quantity": "$(inputs.quantity)",
-					"total":    "$(state.total)",
+					"item":     "${inputs.item}",
+					"quantity": "${inputs.quantity}",
+					"total":    "${state.total}",
 				},
 				Store: "summary",
 				Next:  []*workflow.Edge{{Step: "Print Result"}},

--- a/llms.txt
+++ b/llms.txt
@@ -823,21 +823,21 @@ in automatically via `DefaultScriptCompiler()`; consumers do not need to
 set `ExecutionOptions.ScriptCompiler` unless they want a different
 engine.
 
-Two template syntaxes are available inside parameter values:
+Parameter values use `${expr}` templates. When the template covers the
+entire trimmed value (a single `${...}` with nothing around it), the
+result preserves its native Go type; otherwise the template is
+interpolated into a string.
 
-- `${expr}` — evaluates the expression and inserts the result as a string
-- `$(expr)` — evaluates the expression and inserts the result preserving its type
-
-Available in templates: `state.*` (path variables), `inputs.*` (workflow inputs).
+Available in templates: `state.*` (branch variables), `inputs.*` (workflow inputs).
 
 ```go
 Parameters: map[string]any{
-    "message": "Counter is ${state.counter}, max is ${inputs.max_count}",
-    "number":  "$(state.random_number)",  // preserves numeric type
+    "message": "Counter is ${state.counter}, max is ${inputs.max_count}", // string
+    "number":  "${state.random_number}",                                  // preserves numeric type
 }
 ```
 
-Conditions use the same expression syntax (no `$(…)` wrapper):
+Conditions use the same expression syntax without the `${...}` wrapper:
 
 ```go
 Condition: `state.counter <= inputs.max_count`
@@ -858,7 +858,7 @@ step's `Store` field:
 {
     Name:     "Increment",
     Activity: "increment",            // typed activity: (int) -> int
-    Parameters: map[string]any{"value": "$(state.counter)"},
+    Parameters: map[string]any{"value": "${state.counter}"},
     Store: "state.counter",
 }
 ```
@@ -972,7 +972,7 @@ wf, _ := workflow.New(opts)
     {
       "name": "Increment",
       "activity": "increment",
-      "parameters": {"value": "$(state.counter)"},
+      "parameters": {"value": "${state.counter}"},
       "store": "state.counter",
       "next": [{"step": "Check"}]
     },

--- a/script/eval.go
+++ b/script/eval.go
@@ -7,99 +7,126 @@ import (
 	"strings"
 )
 
+// Template is a parsed ${...} template. Templates are the only
+// interpolation syntax in the workflow engine. A template may be:
+//
+//  1. Literal — contains no ${...} tokens. Eval returns the raw string.
+//  2. Single-expression — the whole trimmed raw string is exactly one
+//     ${expr}. Eval returns the typed value produced by the script
+//     engine (preserving number, bool, array, map, etc.).
+//  3. Interpolated — the raw string mixes literal text with one or
+//     more ${expr} tokens. Eval returns a concatenated string, with
+//     each expression value stringified via Value.String().
+//
+// This is "contextual type inference": callers wishing to pass a
+// typed value (number, bool, slice) through a parameter write the
+// whole value as a single ${...} token; callers building a string
+// (URLs, messages, topics) interpolate tokens inside surrounding text
+// and get a string back.
 type Template struct {
-	raw    string
-	parts  []string
-	codes  []Script
-	engine Compiler
+	raw        string
+	parts      []string // literal segments, interleaved with placeholders ("")
+	scripts    []Script // compiled scripts, one per placeholder
+	singleExpr bool     // raw (trimmed) is exactly one ${...} token
 }
 
-func NewTemplate(engine Compiler, raw string) (*Template, error) {
-	e := &Template{
-		raw:    raw,
-		engine: engine,
-	}
+var templateExprRE = regexp.MustCompile(`\${([^}]+)}`)
 
-	// First validate that all ${...} expressions are properly closed
-	openCount := strings.Count(raw, "${")
-	closeCount := strings.Count(raw, "}")
-	if openCount > closeCount {
+// NewTemplate parses raw as a ${...} template and compiles every
+// expression it contains against engine. Returns an error if any
+// expression is syntactically malformed (unclosed brace) or fails to
+// compile.
+func NewTemplate(engine Compiler, raw string) (*Template, error) {
+	if strings.Count(raw, "${") > strings.Count(raw, "}") {
 		return nil, fmt.Errorf("unclosed template expression in string: %q", raw)
 	}
 
-	if openCount == 0 {
-		// No template variables, just return the raw string
-		return e, nil
-	}
-
-	// Compile all ${...} expressions into Risor code
-	re := regexp.MustCompile(`\${([^}]+)}`)
-	matches := re.FindAllStringSubmatchIndex(raw, -1)
-
+	matches := templateExprRE.FindAllStringSubmatchIndex(raw, -1)
 	if len(matches) == 0 {
-		// No template variables, just return the raw string
-		return e, nil
+		return &Template{raw: raw}, nil
 	}
 
-	var lastEnd int
-	var parts []string
-	var codes []Script
+	var (
+		parts   []string
+		scripts []Script
+		lastEnd int
+	)
 	for _, match := range matches {
-		// Add the text before the match
 		if match[0] > lastEnd {
 			parts = append(parts, raw[lastEnd:match[0]])
 		}
-
-		// Extract and compile the code inside ${...}
 		expr := raw[match[2]:match[3]]
-
-		script, err := engine.Compile(context.Background(), expr)
+		compiled, err := engine.Compile(context.Background(), expr)
 		if err != nil {
 			return nil, fmt.Errorf("failed to compile template expression %q: %w", expr, err)
 		}
-
-		codes = append(codes, script)
-		parts = append(parts, "") // Placeholder for the evaluated result
+		scripts = append(scripts, compiled)
+		parts = append(parts, "") // placeholder
 		lastEnd = match[1]
 	}
-
-	// Add any remaining text after the last match
 	if lastEnd < len(raw) {
 		parts = append(parts, raw[lastEnd:])
 	}
 
+	trimmed := strings.TrimSpace(raw)
+	singleExpr := len(matches) == 1 &&
+		strings.HasPrefix(trimmed, "${") &&
+		strings.HasSuffix(trimmed, "}") &&
+		templateExprRE.FindString(trimmed) == trimmed
+
 	return &Template{
-		raw:   raw,
-		parts: parts,
-		codes: codes,
+		raw:        raw,
+		parts:      parts,
+		scripts:    scripts,
+		singleExpr: singleExpr,
 	}, nil
 }
 
-func (e *Template) Eval(ctx context.Context, globals map[string]any) (string, error) {
-	if len(e.codes) == 0 {
-		// No template variables, return the raw string
+// Eval evaluates the template. For literal templates the raw string
+// is returned as-is. For single-expression templates the script's
+// typed value is returned. For interpolated templates the result is
+// the concatenated string with each expression stringified.
+func (e *Template) Eval(ctx context.Context, globals map[string]any) (any, error) {
+	if len(e.scripts) == 0 {
 		return e.raw, nil
 	}
 
-	// Make a copy of parts since we'll modify it
+	if e.singleExpr {
+		result, err := e.scripts[0].Evaluate(ctx, globals)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate template expression: %w", err)
+		}
+		return result.Value(), nil
+	}
+
 	parts := make([]string, len(e.parts))
 	copy(parts, e.parts)
 
-	// Evaluate each code block and replace the corresponding placeholder
-	for _, code := range e.codes {
-		result, err := code.Evaluate(ctx, globals)
+	scriptIdx := 0
+	for j := range parts {
+		if parts[j] != "" {
+			continue
+		}
+		result, err := e.scripts[scriptIdx].Evaluate(ctx, globals)
 		if err != nil {
 			return "", fmt.Errorf("failed to evaluate template expression: %w", err)
 		}
-		// Find the next empty placeholder and replace it
-		for j := range parts {
-			if parts[j] == "" {
-				parts[j] = result.String()
-				break
-			}
-		}
+		parts[j] = result.String()
+		scriptIdx++
 	}
-
-	// Join all parts to create the final string
 	return strings.Join(parts, ""), nil
+}
+
+// EvalString evaluates the template and always returns a string. For
+// single-expression templates this stringifies the typed value; use
+// Eval instead when preserving the underlying type matters.
+func (e *Template) EvalString(ctx context.Context, globals map[string]any) (string, error) {
+	v, err := e.Eval(ctx, globals)
+	if err != nil {
+		return "", err
+	}
+	if s, ok := v.(string); ok {
+		return s, nil
+	}
+	return fmt.Sprintf("%v", v), nil
 }

--- a/script/eval_test.go
+++ b/script/eval_test.go
@@ -65,7 +65,7 @@ func TestTemplate(t *testing.T) {
 		require.Equal(t, "Hello World", got)
 	})
 
-	t.Run("single template variable", func(t *testing.T) {
+	t.Run("interpolated template returns string", func(t *testing.T) {
 		tmpl, err := NewTemplate(engine, "Hello ${state.name}")
 		require.NoError(t, err)
 		got, err := tmpl.Eval(context.Background(), map[string]any{
@@ -86,6 +86,46 @@ func TestTemplate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, "Hello Bob", got)
+	})
+
+	t.Run("single-expression template preserves int", func(t *testing.T) {
+		tmpl, err := NewTemplate(engine, "${state.count}")
+		require.NoError(t, err)
+		got, err := tmpl.Eval(context.Background(), map[string]any{
+			"state": map[string]any{"count": 42},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 42, got)
+	})
+
+	t.Run("single-expression template preserves bool", func(t *testing.T) {
+		tmpl, err := NewTemplate(engine, "${state.flag}")
+		require.NoError(t, err)
+		got, err := tmpl.Eval(context.Background(), map[string]any{
+			"state": map[string]any{"flag": true},
+		})
+		require.NoError(t, err)
+		require.Equal(t, true, got)
+	})
+
+	t.Run("single-expression template with surrounding whitespace preserves type", func(t *testing.T) {
+		tmpl, err := NewTemplate(engine, "  ${state.count}  ")
+		require.NoError(t, err)
+		got, err := tmpl.Eval(context.Background(), map[string]any{
+			"state": map[string]any{"count": 7},
+		})
+		require.NoError(t, err)
+		require.Equal(t, 7, got)
+	})
+
+	t.Run("EvalString stringifies typed value", func(t *testing.T) {
+		tmpl, err := NewTemplate(engine, "${state.count}")
+		require.NoError(t, err)
+		got, err := tmpl.EvalString(context.Background(), map[string]any{
+			"state": map[string]any{"count": 42},
+		})
+		require.NoError(t, err)
+		require.Equal(t, "42", got)
 	})
 
 	t.Run("unclosed brace is rejected", func(t *testing.T) {

--- a/step.go
+++ b/step.go
@@ -39,13 +39,13 @@ type Each struct {
 // deploy, a human-in-the-loop approval, a callback from an async
 // external system.
 //
-// Topic is a Risor template evaluated at step-entry time against the
-// current path state; the resolved value is what the engine registers
-// as the rendezvous key. Typical patterns:
+// Topic is a template evaluated at step-entry time against the
+// current branch state; the resolved value is what the engine
+// registers as the rendezvous key. Typical patterns:
 //
 //   - Static:   "approval-requested"
 //   - Dynamic:  "callback-${state.request_id}"
-//   - Script:   "$(state.meta.correlation_id)"
+//   - Expression: "${state.meta.correlation_id}"
 //
 // Store is the variable name that receives the signal payload when it
 // arrives. Like Step.Store, a "state." prefix is stripped.

--- a/validate.go
+++ b/validate.go
@@ -266,8 +266,7 @@ func (w *Workflow) branchExists(name string) bool {
 //
 // Checks performed:
 //  1. Activity references resolve in the registry.
-//  2. Parameter templates ("${...}") and bare script expressions
-//     ("$(...)") compile against the given compiler.
+//  2. Parameter templates ("${...}") compile against the given compiler.
 //  3. Edge condition expressions compile.
 //  4. WaitSignalConfig.Topic templates compile.
 //  5. Step.Store, WaitSignalConfig.Store, CatchConfig.Store, and
@@ -289,7 +288,7 @@ func (w *Workflow) validateBinding(reg *ActivityRegistry, compiler script.Compil
 	ctx := context.Background()
 
 	// Helper: compile a parameter value recursively, flagging any
-	// template or $(...) expression that fails to parse.
+	// ${...} template that fails to parse.
 	var checkParamValue func(stepName, paramName string, value any)
 	checkParamValue = func(stepName, paramName string, value any) {
 		switch v := value.(type) {
@@ -320,28 +319,24 @@ func (w *Workflow) validateBinding(reg *ActivityRegistry, compiler script.Compil
 		}
 	}
 
-	// 2. Parameter templates and $(...) expressions.
+	// 2. Parameter templates.
 	for _, step := range w.steps {
 		for name, value := range step.Parameters {
 			checkParamValue(step.Name, name, value)
 		}
 	}
 
-	// 3. Edge condition expressions.
+	// 3. Edge condition expressions (raw script expressions).
 	for _, step := range w.steps {
 		for i, edge := range step.Next {
 			if edge.Condition == "" {
 				continue
 			}
-			cond := edge.Condition
-			switch strings.ToLower(strings.TrimSpace(cond)) {
+			switch strings.ToLower(strings.TrimSpace(edge.Condition)) {
 			case "true", "false":
 				continue
 			}
-			if strings.HasPrefix(cond, "$(") && strings.HasSuffix(cond, ")") {
-				cond = strings.TrimSuffix(strings.TrimPrefix(cond, "$("), ")")
-			}
-			if _, err := compiler.Compile(ctx, cond); err != nil {
+			if _, err := compiler.Compile(ctx, edge.Condition); err != nil {
 				add(step.Name,
 					fmt.Sprintf("edge[%d] condition %q: %v", i, edge.Condition, err),
 					ErrInvalidExpression)
@@ -357,15 +352,7 @@ func (w *Workflow) validateBinding(reg *ActivityRegistry, compiler script.Compil
 		}
 		usesWaitSignal = true
 		if ws.Topic != "" {
-			topic := ws.Topic
-			if strings.HasPrefix(topic, "$(") && strings.HasSuffix(topic, ")") {
-				topic = strings.TrimSuffix(strings.TrimPrefix(topic, "$("), ")")
-				if _, err := compiler.Compile(ctx, topic); err != nil {
-					add(step.Name,
-						fmt.Sprintf("wait_signal topic %q: %v", ws.Topic, err),
-						ErrInvalidTemplate)
-				}
-			} else if _, err := script.NewTemplate(compiler, topic); err != nil {
+			if _, err := script.NewTemplate(compiler, ws.Topic); err != nil {
 				add(step.Name,
 					fmt.Sprintf("wait_signal topic %q: %v", ws.Topic, err),
 					ErrInvalidTemplate)
@@ -420,17 +407,9 @@ func hasStatePrefix(s string) bool {
 }
 
 // checkParamString compiles a single parameter string value, reporting
-// any parse or compile failure as a ValidationProblem.
+// any template parse failure as a ValidationProblem.
 func checkParamString(ctx context.Context, compiler script.Compiler, stepName, paramName, value string, add func(step, msg string, sentinel error)) {
-	if strings.HasPrefix(value, "$(") && strings.HasSuffix(value, ")") {
-		code := strings.TrimSuffix(strings.TrimPrefix(value, "$("), ")")
-		if _, err := compiler.Compile(ctx, code); err != nil {
-			add(stepName,
-				fmt.Sprintf("parameter %q: %v", paramName, err),
-				ErrInvalidExpression)
-		}
-		return
-	}
+	_ = ctx
 	if strings.Contains(value, "${") {
 		if _, err := script.NewTemplate(compiler, value); err != nil {
 			add(stepName,

--- a/validate_test.go
+++ b/validate_test.go
@@ -198,7 +198,7 @@ func TestBindingValidation_UnknownActivity(t *testing.T) {
 	require.True(t, errors.Is(err, ErrUnknownActivity))
 }
 
-func TestBindingValidation_BadParameterExpression(t *testing.T) {
+func TestBindingValidation_BadParameterTemplateExpression(t *testing.T) {
 	wf, err := New(Options{
 		Name: "bad-param",
 		Steps: []*Step{
@@ -206,7 +206,7 @@ func TestBindingValidation_BadParameterExpression(t *testing.T) {
 				Name:     "start",
 				Activity: "a",
 				Parameters: map[string]any{
-					"value": "$(!!bogus!!)",
+					"value": "${!!bogus!!}",
 				},
 			},
 		},
@@ -215,7 +215,7 @@ func TestBindingValidation_BadParameterExpression(t *testing.T) {
 
 	_, err = NewExecution(wf, bindingReg(), WithScriptCompiler(newTestCompiler()))
 	require.Error(t, err)
-	require.True(t, errors.Is(err, ErrInvalidExpression))
+	require.True(t, errors.Is(err, ErrInvalidTemplate))
 }
 
 func TestBindingValidation_BadParameterTemplate(t *testing.T) {
@@ -386,7 +386,7 @@ func TestBindingValidation_CollectsMultipleProblems(t *testing.T) {
 				Activity: "missing",
 				Store:    "state.result",
 				Parameters: map[string]any{
-					"x": "$(!!bogus!!)",
+					"x": "${!!bogus!!}",
 				},
 			},
 		},
@@ -400,7 +400,7 @@ func TestBindingValidation_CollectsMultipleProblems(t *testing.T) {
 	require.True(t, errors.As(err, &ve))
 	require.GreaterOrEqual(t, len(ve.Problems), 3)
 	require.True(t, errors.Is(err, ErrUnknownActivity))
-	require.True(t, errors.Is(err, ErrInvalidExpression))
+	require.True(t, errors.Is(err, ErrInvalidTemplate))
 	require.True(t, errors.Is(err, ErrInvalidStorePath))
 }
 


### PR DESCRIPTION
## Summary

One template syntax, contextual type inference. Deletes `$(...)` parsing entirely — `${...}` is the only form. When a parameter value is a single `${...}` covering the whole trimmed string, the result preserves its native Go type; otherwise the template is interpolated into a string. Edge conditions and `each.Items` are raw expressions (no wrapper).

Per §12 of the API review: the two-syntax design differed by one character and was a confusion factory. Pre-v1 posture means no deprecation needed.

## Changes

- `script/eval.go` — parse only `${...}`; single-expression templates preserve typed values, interpolated templates return strings.
- `script/eval_test.go` — cover int/bool/whitespace single-expression and `EvalString` stringification.
- `branch.go` — drop `$(...)` handling; conditions and `each.Items` are raw expressions; parameter templates unified on `${...}`.
- `validate.go` — drop `$(...)` branches in parameter/condition/topic validation.
- `branch_test.go`, `coverage_test.go`, `validate_test.go` — rewrite to use `${...}` templates.
- `examples/{child_workflows,branching,simple,structured_result}` — migrate to `${...}`.
- `step.go`, `README.md`, `llms.txt`, `CLAUDE.md`, `examples/join_branches/README.md` — doc/comment cleanup removing `$(...)` references.

## Test plan

- [x] `go test -count=1 ./...` passes
- [x] `go vet ./...` clean
- [x] `grep '\\$('` returns no hits outside `planning/review/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)