### PR TITLE
PR10: child workflow fixes

### DIFF
--- a/activities/child_workflow_activity.go
+++ b/activities/child_workflow_activity.go
@@ -1,23 +1,27 @@
 package activities
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/deepnoodle-ai/workflow"
 )
 
-// ChildWorkflowInput defines the input parameters for the child workflow activity
+// ChildWorkflowInput defines the input parameters for the child workflow activity.
+//
+// The activity always runs the child synchronously: the parent step
+// blocks until the child completes (or times out) and the result is
+// stored under Step.Store. Workflows that need fire-and-forget
+// behavior should call ChildWorkflowExecutor.ExecuteAsync directly
+// from a custom activity.
 type ChildWorkflowInput struct {
 	WorkflowName string                 `json:"workflow_name"`
-	Sync         bool                   `json:"sync"`
 	Inputs       map[string]interface{} `json:"inputs"`
 	Timeout      time.Duration          `json:"timeout"`
 	ParentID     string                 `json:"parent_id"`
 }
 
-// ChildWorkflowActivity can be used to execute child workflows
+// ChildWorkflowActivity executes a registered child workflow synchronously.
 type ChildWorkflowActivity struct {
 	executor workflow.ChildWorkflowExecutor
 }
@@ -36,62 +40,32 @@ func (c *ChildWorkflowActivity) Name() string {
 
 // Execute runs the child workflow activity
 func (c *ChildWorkflowActivity) Execute(ctx workflow.Context, params ChildWorkflowInput) (map[string]any, error) {
-	// Validate workflow name (required)
 	if params.WorkflowName == "" {
 		return nil, fmt.Errorf("child workflow activity requires 'workflow_name' parameter")
 	}
 
-	// Initialize inputs if nil
 	inputs := params.Inputs
 	if inputs == nil {
 		inputs = make(map[string]interface{})
 	}
 
-	// Create child workflow spec
 	spec := &workflow.ChildWorkflowSpec{
 		WorkflowName: params.WorkflowName,
 		Inputs:       inputs,
 		Timeout:      params.Timeout,
 		ParentID:     params.ParentID,
-		Sync:         params.Sync,
 	}
 
-	// Execute based on sync flag
-	if params.Sync {
-		return c.executeSync(ctx, spec)
-	} else {
-		return c.executeAsync(ctx, spec)
-	}
-}
-
-// executeSync runs the child workflow synchronously
-func (c *ChildWorkflowActivity) executeSync(ctx context.Context, spec *workflow.ChildWorkflowSpec) (map[string]any, error) {
 	result, err := c.executor.ExecuteSync(ctx, spec)
 	if err != nil {
 		return nil, fmt.Errorf("child workflow execution failed: %w", err)
 	}
 
-	// For synchronous execution, we return the result
 	return map[string]any{
 		"outputs":      result.Outputs,
 		"status":       string(result.Status),
 		"execution_id": result.ExecutionID,
 		"duration":     result.Duration.Seconds(),
 		"success":      result.Status == workflow.ExecutionStatusCompleted,
-	}, nil
-}
-
-// executeAsync starts the child workflow asynchronously
-func (c *ChildWorkflowActivity) executeAsync(ctx context.Context, spec *workflow.ChildWorkflowSpec) (map[string]any, error) {
-	handle, err := c.executor.ExecuteAsync(ctx, spec)
-	if err != nil {
-		return nil, fmt.Errorf("failed to start child workflow: %w", err)
-	}
-
-	// For asynchronous execution, we return the handle for later reference
-	return map[string]any{
-		"execution_id":  handle.ExecutionID,
-		"workflow_name": handle.WorkflowName,
-		"async":         true,
 	}, nil
 }

--- a/activities/child_workflow_activity_test.go
+++ b/activities/child_workflow_activity_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestChildWorkflowActivity(t *testing.T) {
-	t.Run("sync execution", func(t *testing.T) {
+	t.Run("runs registered child workflow", func(t *testing.T) {
 		wf, err := workflow.New(workflow.Options{
 			Name: "child",
 			Steps: []*workflow.Step{
@@ -38,40 +38,11 @@ func TestChildWorkflowActivity(t *testing.T) {
 		require.Equal(t, "workflow.child", activity.Name())
 
 		ctx := newTestContext()
-		result, err := activity.Execute(ctx, map[string]any{"workflow_name": "child", "sync": true})
+		result, err := activity.Execute(ctx, map[string]any{"workflow_name": "child"})
 		require.NoError(t, err)
 		m := result.(map[string]any)
 		require.Equal(t, true, m["success"])
 		require.Equal(t, "completed", m["status"])
-	})
-
-	t.Run("async execution", func(t *testing.T) {
-		wf, err := workflow.New(workflow.Options{
-			Name:  "async-child",
-			Steps: []*workflow.Step{{Name: "work", Activity: "work"}},
-		})
-		require.NoError(t, err)
-
-		reg := workflow.NewMemoryWorkflowRegistry()
-		reg.Register(wf)
-
-		workAct := workflow.ActivityFunc("work", func(ctx workflow.Context, params map[string]any) (any, error) {
-			return "done", nil
-		})
-
-		executor, err := workflow.NewDefaultChildWorkflowExecutor(workflow.ChildWorkflowExecutorOptions{
-			WorkflowRegistry: reg,
-			Activities:       []workflow.Activity{workAct},
-		})
-		require.NoError(t, err)
-
-		activity := NewChildWorkflowActivity(executor)
-		ctx := newTestContext()
-		result, err := activity.Execute(ctx, map[string]any{"workflow_name": "async-child", "sync": false})
-		require.NoError(t, err)
-		m := result.(map[string]any)
-		require.Equal(t, true, m["async"])
-		require.NotEmpty(t, m["execution_id"])
 	})
 
 	t.Run("missing workflow_name", func(t *testing.T) {
@@ -86,14 +57,14 @@ func TestChildWorkflowActivity(t *testing.T) {
 		require.Contains(t, err.Error(), "workflow_name")
 	})
 
-	t.Run("workflow not found sync", func(t *testing.T) {
+	t.Run("workflow not found", func(t *testing.T) {
 		executor, err := workflow.NewDefaultChildWorkflowExecutor(workflow.ChildWorkflowExecutorOptions{
 			WorkflowRegistry: workflow.NewMemoryWorkflowRegistry(),
 		})
 		require.NoError(t, err)
 		activity := NewChildWorkflowActivity(executor)
 		ctx := newTestContext()
-		_, err = activity.Execute(ctx, map[string]any{"workflow_name": "missing", "sync": true})
+		_, err = activity.Execute(ctx, map[string]any{"workflow_name": "missing"})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "child workflow execution failed")
 	})

--- a/child_workflow.go
+++ b/child_workflow.go
@@ -10,22 +10,27 @@ import (
 	"github.com/deepnoodle-ai/workflow/script"
 )
 
-// ChildWorkflowSpec specifies how to execute a child workflow
+// ChildWorkflowSpec specifies how to execute a child workflow.
+//
+// Whether the child runs synchronously or asynchronously is selected
+// at the call site by invoking ChildWorkflowExecutor.ExecuteSync or
+// ExecuteAsync — there is no flag on the spec.
 type ChildWorkflowSpec struct {
 	WorkflowName string                 `json:"workflow_name"`
 	Inputs       map[string]interface{} `json:"inputs,omitempty"`
 	Timeout      time.Duration          `json:"timeout,omitempty"`
 	ParentID     string                 `json:"parent_id,omitempty"` // for tracing
-	Sync         bool                   `json:"sync"`                // synchronous vs asynchronous
 }
 
-// ChildWorkflowResult represents the result of a child workflow execution
+// ChildWorkflowResult represents the result of a child workflow execution.
+//
+// The execution error is the second return value from
+// ExecuteSync/GetResult — it is not duplicated on this struct.
 type ChildWorkflowResult struct {
 	Outputs     map[string]interface{} `json:"outputs"`
 	Status      ExecutionStatus        `json:"status"`
 	ExecutionID string                 `json:"execution_id"`
 	Duration    time.Duration          `json:"duration"`
-	Error       error                  `json:"error,omitempty"`
 }
 
 // ChildWorkflowHandle represents an asynchronous child workflow execution
@@ -98,6 +103,12 @@ func (r *MemoryWorkflowRegistry) List() []string {
 	return names
 }
 
+// defaultAsyncCleanupTimeout is the default window during which an
+// asynchronously launched child workflow's result remains retrievable
+// via GetResult after it completes. Consumers can override via
+// ChildWorkflowExecutorOptions.CleanupTimeout.
+const defaultAsyncCleanupTimeout = time.Hour
+
 // DefaultChildWorkflowExecutor provides a basic implementation of ChildWorkflowExecutor
 type DefaultChildWorkflowExecutor struct {
 	workflowRegistry   WorkflowRegistry
@@ -106,6 +117,7 @@ type DefaultChildWorkflowExecutor struct {
 	activityLogger     ActivityLogger
 	checkpointer       Checkpointer
 	scriptCompiler     script.Compiler
+	cleanupTimeout     time.Duration
 	asyncExecutions    map[string]*Execution // Track async executions by ID
 	asyncExecutionsMtx sync.RWMutex          // Protect concurrent access to async executions
 }
@@ -122,6 +134,13 @@ type ChildWorkflowExecutorOptions struct {
 	// (github.com/deepnoodle-ai/expr). Set this to override with a
 	// different engine.
 	ScriptCompiler script.Compiler
+	// CleanupTimeout is how long to retain an async child workflow's
+	// result in memory after completion before evicting it from the
+	// in-flight map. GetResult on an evicted handle returns an error.
+	// Zero (the default) means one hour. Negative values disable
+	// cleanup entirely (results are retained for the lifetime of the
+	// process — useful in tests, dangerous in long-running services).
+	CleanupTimeout time.Duration
 }
 
 // NewDefaultChildWorkflowExecutor creates a new DefaultChildWorkflowExecutor
@@ -129,7 +148,10 @@ func NewDefaultChildWorkflowExecutor(opts ChildWorkflowExecutorOptions) (*Defaul
 	if opts.WorkflowRegistry == nil {
 		return nil, fmt.Errorf("workflow registry is required")
 	}
-
+	cleanup := opts.CleanupTimeout
+	if cleanup == 0 {
+		cleanup = defaultAsyncCleanupTimeout
+	}
 	return &DefaultChildWorkflowExecutor{
 		workflowRegistry:   opts.WorkflowRegistry,
 		activities:         opts.Activities,
@@ -137,6 +159,7 @@ func NewDefaultChildWorkflowExecutor(opts ChildWorkflowExecutorOptions) (*Defaul
 		activityLogger:     opts.ActivityLogger,
 		checkpointer:       opts.Checkpointer,
 		scriptCompiler:     opts.ScriptCompiler,
+		cleanupTimeout:     cleanup,
 		asyncExecutions:    make(map[string]*Execution),
 		asyncExecutionsMtx: sync.RWMutex{},
 	}, nil
@@ -171,7 +194,6 @@ func (e *DefaultChildWorkflowExecutor) ExecuteSync(ctx context.Context, spec *Ch
 		ExecutionID: execution.ID(),
 		Status:      execution.Status(),
 		Duration:    duration,
-		Error:       execErr,
 	}
 	if result != nil {
 		cwr.Outputs = make(map[string]any, len(result.Outputs))
@@ -213,7 +235,32 @@ func (e *DefaultChildWorkflowExecutor) newChildExecution(wf *Workflow, spec *Chi
 	return exec, nil
 }
 
-// ExecuteAsync starts a child workflow asynchronously
+// ExecuteAsync starts a child workflow asynchronously and returns a
+// handle immediately. The child runs in a detached goroutine that
+// uses context.Background(), so the caller's context cancellation
+// does not propagate.
+//
+// # Async vs. checkpoint semantics
+//
+// The async execution map is in-process state. It is NOT part of the
+// parent execution's checkpoint:
+//
+//   - If the parent process restarts while an async child is running,
+//     the child goroutine dies with the process. The parent's resumed
+//     execution will hold a ChildWorkflowHandle that no longer
+//     resolves: GetResult returns "not found".
+//   - If the parent execution checkpoints and resumes in the same
+//     process, the handle still resolves until cleanupTimeout elapses
+//     after the child completes.
+//
+// In short: async children are best-effort, single-process. Workflows
+// that need durable child orchestration across restarts should use
+// ExecuteSync (the parent execution waits, the checkpoint captures
+// the child's outputs in state) or model the child as a separate
+// top-level execution coordinated via signals.
+//
+// TODO(v1.1): persist async-child handles to the checkpointer so that
+// resumed parents can re-attach.
 func (e *DefaultChildWorkflowExecutor) ExecuteAsync(ctx context.Context, spec *ChildWorkflowSpec) (*ChildWorkflowHandle, error) {
 	workflow, exists := e.workflowRegistry.Get(spec.WorkflowName)
 	if !exists {
@@ -230,14 +277,18 @@ func (e *DefaultChildWorkflowExecutor) ExecuteAsync(ctx context.Context, spec *C
 	e.asyncExecutions[execution.ID()] = execution
 	e.asyncExecutionsMtx.Unlock()
 
+	cleanup := e.cleanupTimeout
+
 	// Start execution in a goroutine. Use context.Background() instead of
 	// the caller's context so that the async child workflow is not cancelled
 	// when the caller's context completes.
 	go func() {
 		defer func() {
-			// Clean up completed execution after a delay to allow result retrieval
+			if cleanup < 0 {
+				return
+			}
 			go func() {
-				time.Sleep(5 * time.Minute) // Keep results available for 5 minutes
+				time.Sleep(cleanup)
 				e.asyncExecutionsMtx.Lock()
 				delete(e.asyncExecutions, execution.ID())
 				e.asyncExecutionsMtx.Unlock()
@@ -251,7 +302,6 @@ func (e *DefaultChildWorkflowExecutor) ExecuteAsync(ctx context.Context, spec *C
 			defer cancel()
 		}
 
-		// Run the execution (errors will be captured in execution status)
 		execution.Execute(execCtx)
 	}()
 
@@ -286,7 +336,6 @@ func (e *DefaultChildWorkflowExecutor) GetResult(ctx context.Context, handle *Ch
 			Status:      status,
 			Duration:    0, // Duration not available until completion
 			Outputs:     make(map[string]any),
-			Error:       nil,
 		}, nil
 	}
 
@@ -295,19 +344,14 @@ func (e *DefaultChildWorkflowExecutor) GetResult(ctx context.Context, handle *Ch
 	result := &ChildWorkflowResult{
 		ExecutionID: execution.ID(),
 		Status:      status,
-		Outputs:     make(map[string]any),
+		Outputs:     make(map[string]any, len(outputs)),
 	}
-
-	// Copy outputs
 	for k, v := range outputs {
 		result.Outputs[k] = v
 	}
 
-	// Set error if execution failed
 	if status == ExecutionStatusFailed {
-		// We don't have direct access to execution error, so create a generic one
-		result.Error = fmt.Errorf("child workflow execution failed")
+		return result, fmt.Errorf("child workflow execution failed")
 	}
-
 	return result, nil
 }

--- a/examples/child_workflows/README.md
+++ b/examples/child_workflows/README.md
@@ -1,16 +1,23 @@
 # Child Workflows Example
 
-This example demonstrates the new child workflow functionality,
-inspired by AWS Step Functions' nested workflow capabilities.
+This example demonstrates the child workflow functionality, inspired
+by AWS Step Functions' nested workflow capabilities. The parent
+workflow synchronously orchestrates two child workflows and waits for
+each to complete before continuing.
 
 ## What This Example Shows
 
 ### Core Features
-1. **Parent-Child Workflow Orchestration**: A main workflow that orchestrates multiple child workflows
-2. **Synchronous Execution**: Parent workflow waits for child workflows to complete
-3. **Data Flow**: Seamless data passing between parent and child workflows
-4. **State Integration**: Child workflow results are integrated into parent workflow state
-5. **Workflow Registry**: Managing multiple workflow definitions in a centralized registry
+
+1. **Parent-Child Orchestration**: A parent workflow runs two child
+   workflows in sequence.
+2. **Wait for Completion**: The `workflow.child` activity blocks the
+   parent step until the child finishes (or its `timeout` elapses),
+   then writes the result into parent state via `Step.Store`.
+3. **Data Flow**: Inputs are templated from parent state with `${...}`
+   and the child's outputs are read back through the stored result.
+4. **Workflow Registry**: A central registry holds the child
+   workflow definitions so the activity can resolve them by name.
 
 ### Architecture Overview
 
@@ -21,7 +28,7 @@ Main Orchestrator Workflow (Parent)
 │   ├── Process Input Data
 │   └── Return Result
 ├── Extract Result from Child
-├── → Child: Data Validator Workflow  
+├── → Child: Data Validator Workflow
 │   ├── Validate Input
 │   └── Report Validation
 ├── Check Validation Result
@@ -32,22 +39,62 @@ Main Orchestrator Workflow (Parent)
 
 ### 1. WorkflowRegistry
 
-- **Purpose**: Manages multiple workflow definitions
-- **Implementation**: In-memory registry for this example
-- **Usage**: Register child workflows that can be called by name
+In-memory registry of child workflow definitions, looked up by name.
 
-### 2. ChildWorkflowExecutor 
+### 2. ChildWorkflowExecutor
 
-- **Purpose**: Manages child workflow execution lifecycle
-- **Features**: Synchronous and asynchronous execution patterns
-- **Integration**: Works with existing activity system
+Owns the lifecycle of child executions. The interface exposes both
+`ExecuteSync` (block until done) and `ExecuteAsync` (return a handle,
+poll via `GetResult`). The bundled `workflow.child` activity always
+calls `ExecuteSync`; build your own activity if you need fire-and-
+forget semantics.
 
-### 3. ChildWorkflowActivity
+### 3. `workflow.child` activity
 
-- **Purpose**: Activity that executes child workflows
 - **Activity Name**: `"workflow.child"`
-- **Parameters**: 
+- **Parameters**:
   - `workflow_name`: Name of child workflow to execute
-  - `sync`: Boolean for synchronous vs asynchronous execution
-  - `timeout`: Optional timeout duration
-  - `inputs`: Data to pass to child workflow
+  - `timeout`: `time.Duration` cap on the child execution (0 = no cap)
+  - `inputs`: Data to pass to the child as workflow inputs
+  - `parent_id`: Optional tracing ID
+
+## Wait-for-Completion Pattern
+
+The "wait for child" pattern in this library is just `workflow.child`
+with `Step.Store`:
+
+```go
+{
+    Name:     "Call Data Processor",
+    Activity: "workflow.child",
+    Parameters: map[string]any{
+        "workflow_name": "data-processor",
+        "timeout":       30 * time.Second,
+        "inputs":        map[string]any{"raw_data": "${state.raw_data}"},
+    },
+    Store: "processing_workflow_result",
+    Next:  []*workflow.Edge{{Step: "Extract Result"}},
+}
+```
+
+The parent step does not advance until the child has reached a
+terminal state. The stored result has shape:
+
+```go
+map[string]any{
+    "outputs":      map[string]any{ /* child outputs */ },
+    "status":       "completed",
+    "execution_id": "exec_…",
+    "duration":     1.234, // seconds
+    "success":      true,
+}
+```
+
+## Async children and durability
+
+`ExecuteAsync` is single-process and non-durable: the in-flight handle
+lives in memory only. If the parent process restarts while an async
+child is running, the child goroutine dies with the process and the
+resumed parent can no longer resolve its handle. For workflows that
+must survive restarts, use `ExecuteSync` (this example), or model the
+child as an independent top-level execution coordinated via signals.

--- a/examples/child_workflows/main.go
+++ b/examples/child_workflows/main.go
@@ -230,8 +230,7 @@ func main() {
 				Activity: "workflow.child",
 				Parameters: map[string]any{
 					"workflow_name": "data-processor",
-					"sync":          true,
-					"timeout":       30,
+					"timeout":       30 * time.Second,
 					"inputs": map[string]any{
 						"raw_data": "${state.raw_data}",
 					},
@@ -253,8 +252,7 @@ func main() {
 				Activity: "workflow.child",
 				Parameters: map[string]any{
 					"workflow_name": "data-validator",
-					"sync":          true,
-					"timeout":       30,
+					"timeout":       30 * time.Second,
 					"inputs": map[string]any{
 						"data_to_validate": "${state.processed_data}",
 					},


### PR DESCRIPTION
## Summary

Per decision 1.15 of the v1 plan: keep child workflows in the public API and fix the concrete bugs.

- **`ChildWorkflowSpec.Sync` deleted.** The `ExecuteSync`/`ExecuteAsync` split on the executor interface is the source of truth; flagging on the spec was redundant and confusing.
- **`ChildWorkflowResult.Error` dropped.** The execution error is already the second return value of `ExecuteSync`/`GetResult` — duplicating it on the struct led to two sources of truth.
- **`ChildWorkflowExecutorOptions.CleanupTimeout` added.** Default `1h` (was a hardcoded 5-minute `time.Sleep`); zero uses the default; negative disables eviction entirely (useful in tests). Replaces the magic 5-minute sleep.
- **`ExecuteAsync` godoc** now spells out the async-vs-checkpoint contract: async children are in-process only, die with the process, parent loses the handle on restart. Includes a `TODO(v1.1)` for durable async-child handles.
- **`activities/child_workflow_activity.go`** is sync-only. Drops the `Sync` field from `ChildWorkflowInput` and the `executeSync`/`executeAsync` branching. Consumers needing fire-and-forget build their own activity wrapping `executor.ExecuteAsync`.
- **`activities/child_workflow_activity_test.go`** drops the async path test and the `"sync": true` parameter from remaining cases.
- **`examples/child_workflows/main.go`** drops `"sync": true` and switches timeouts to `time.Duration` literals.
- **`examples/child_workflows/README.md`** rewritten to document the wait-for-completion pattern (which is just `workflow.child` with `Step.Store`) and the async durability caveat.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` passes
- [x] `go build ./...` clean (cmd/workflow + all examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)