### PR TITLE
PR12: ExecutionResult helpers

### DIFF
--- a/execution_result.go
+++ b/execution_result.go
@@ -139,3 +139,121 @@ func (r *ExecutionResult) Paused() bool {
 func (r *ExecutionResult) NeedsResume() bool {
 	return r.Suspended() || r.Paused()
 }
+
+// Output returns the raw output value at key and whether it was
+// present. Returns (nil, false) when the result has no outputs map
+// or the key is missing.
+func (r *ExecutionResult) Output(key string) (any, bool) {
+	if r == nil || r.Outputs == nil {
+		return nil, false
+	}
+	v, ok := r.Outputs[key]
+	return v, ok
+}
+
+// OutputString returns the output at key as a string and whether the
+// type assertion succeeded. Returns ("", false) if the key is missing
+// or the value is not a string.
+func (r *ExecutionResult) OutputString(key string) (string, bool) {
+	v, ok := r.Output(key)
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// OutputInt returns the output at key as an int and whether the
+// conversion succeeded. Recognises Go's numeric types (int, int32,
+// int64, float32, float64) so values that round-tripped through JSON
+// (where numbers come back as float64) work as expected. Returns
+// (0, false) if the key is missing or the value is not numeric.
+//
+// Float values are truncated to int; precision loss is the caller's
+// responsibility — use OutputAs[float64] when fractional precision
+// matters.
+func (r *ExecutionResult) OutputInt(key string) (int, bool) {
+	v, ok := r.Output(key)
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// OutputBool returns the output at key as a bool and whether the
+// type assertion succeeded. Returns (false, false) if the key is
+// missing or the value is not a bool.
+func (r *ExecutionResult) OutputBool(key string) (bool, bool) {
+	v, ok := r.Output(key)
+	if !ok {
+		return false, false
+	}
+	b, ok := v.(bool)
+	return b, ok
+}
+
+// WaitReason returns the dominant suspension reason if the execution
+// is suspended, or empty string otherwise. Convenience for the common
+// "what kind of resume do I need to schedule?" question.
+func (r *ExecutionResult) WaitReason() SuspensionReason {
+	if r == nil || r.Suspension == nil {
+		return ""
+	}
+	return r.Suspension.Reason
+}
+
+// Topics returns the union of signal topics that suspended branches
+// are waiting on, or nil if the execution is not suspended on a
+// signal-wait. Consumers use this to register signal listeners
+// before scheduling a resume.
+func (r *ExecutionResult) Topics() []string {
+	if r == nil || r.Suspension == nil {
+		return nil
+	}
+	return r.Suspension.Topics
+}
+
+// NextWakeAt returns the earliest wall-clock deadline across all
+// suspended branches and whether one is set. Returns (zero, false)
+// if the execution is not suspended or no branch has a deadline.
+// Consumers use this to schedule a wall-clock resume — typical use
+// is `time.AfterFunc(time.Until(t), resumeFn)`.
+func (r *ExecutionResult) NextWakeAt() (time.Time, bool) {
+	if r == nil || r.Suspension == nil || r.Suspension.WakeAt.IsZero() {
+		return time.Time{}, false
+	}
+	return r.Suspension.WakeAt, true
+}
+
+// OutputAs returns the output at key coerced to T and whether the
+// type assertion succeeded. Generic counterpart to OutputString /
+// OutputBool for arbitrary types — useful when consumers store
+// custom structs in workflow outputs.
+//
+// Returns (zero T, false) if the key is missing or the value cannot
+// be type-asserted to T. No JSON-style conversion is performed; the
+// value must already be of type T (or assignable to it).
+func OutputAs[T any](r *ExecutionResult, key string) (T, bool) {
+	var zero T
+	v, ok := r.Output(key)
+	if !ok {
+		return zero, false
+	}
+	t, ok := v.(T)
+	if !ok {
+		return zero, false
+	}
+	return t, true
+}

--- a/execution_result_test.go
+++ b/execution_result_test.go
@@ -128,6 +128,131 @@ func TestExecuteInterruptedHasValidDuration(t *testing.T) {
 	require.True(t, result.Timing.Duration > 0, "Duration should be positive for interrupted executions")
 }
 
+func TestExecutionResultOutputHelpers(t *testing.T) {
+	r := &ExecutionResult{
+		Outputs: map[string]any{
+			"name":    "alice",
+			"count":   42,
+			"score":   3.14,
+			"i64":     int64(99),
+			"enabled": true,
+		},
+	}
+
+	t.Run("Output", func(t *testing.T) {
+		v, ok := r.Output("name")
+		require.True(t, ok)
+		require.Equal(t, "alice", v)
+
+		_, ok = r.Output("missing")
+		require.False(t, ok)
+	})
+
+	t.Run("OutputString", func(t *testing.T) {
+		s, ok := r.OutputString("name")
+		require.True(t, ok)
+		require.Equal(t, "alice", s)
+
+		_, ok = r.OutputString("count")
+		require.False(t, ok, "non-string should return false")
+
+		_, ok = r.OutputString("missing")
+		require.False(t, ok)
+	})
+
+	t.Run("OutputInt", func(t *testing.T) {
+		n, ok := r.OutputInt("count")
+		require.True(t, ok)
+		require.Equal(t, 42, n)
+
+		n, ok = r.OutputInt("i64")
+		require.True(t, ok)
+		require.Equal(t, 99, n)
+
+		// float64 (JSON-decoded numbers) is supported and truncated.
+		n, ok = r.OutputInt("score")
+		require.True(t, ok)
+		require.Equal(t, 3, n)
+
+		_, ok = r.OutputInt("name")
+		require.False(t, ok)
+
+		_, ok = r.OutputInt("missing")
+		require.False(t, ok)
+	})
+
+	t.Run("OutputBool", func(t *testing.T) {
+		b, ok := r.OutputBool("enabled")
+		require.True(t, ok)
+		require.True(t, b)
+
+		_, ok = r.OutputBool("count")
+		require.False(t, ok)
+	})
+
+	t.Run("OutputAs generic", func(t *testing.T) {
+		s, ok := OutputAs[string](r, "name")
+		require.True(t, ok)
+		require.Equal(t, "alice", s)
+
+		// type mismatch returns zero value + false
+		_, ok = OutputAs[int](r, "name")
+		require.False(t, ok)
+
+		_, ok = OutputAs[string](r, "missing")
+		require.False(t, ok)
+	})
+
+	t.Run("nil-safe", func(t *testing.T) {
+		var nilResult *ExecutionResult
+		_, ok := nilResult.Output("any")
+		require.False(t, ok)
+		_, ok = nilResult.OutputString("any")
+		require.False(t, ok)
+		_, ok = nilResult.OutputInt("any")
+		require.False(t, ok)
+		_, ok = nilResult.OutputBool("any")
+		require.False(t, ok)
+		_, ok = OutputAs[string](nilResult, "any")
+		require.False(t, ok)
+	})
+}
+
+func TestExecutionResultSuspensionHelpers(t *testing.T) {
+	t.Run("not suspended", func(t *testing.T) {
+		r := &ExecutionResult{Status: ExecutionStatusCompleted}
+		require.Equal(t, SuspensionReason(""), r.WaitReason())
+		require.Nil(t, r.Topics())
+		_, ok := r.NextWakeAt()
+		require.False(t, ok)
+	})
+
+	t.Run("waiting on signals", func(t *testing.T) {
+		wakeAt := time.Now().Add(2 * time.Hour)
+		r := &ExecutionResult{
+			Status: ExecutionStatusSuspended,
+			Suspension: &SuspensionInfo{
+				Reason: SuspensionReasonWaitingSignal,
+				Topics: []string{"approval", "callback"},
+				WakeAt: wakeAt,
+			},
+		}
+		require.Equal(t, SuspensionReasonWaitingSignal, r.WaitReason())
+		require.Equal(t, []string{"approval", "callback"}, r.Topics())
+		got, ok := r.NextWakeAt()
+		require.True(t, ok)
+		require.Equal(t, wakeAt, got)
+	})
+
+	t.Run("nil-safe", func(t *testing.T) {
+		var r *ExecutionResult
+		require.Equal(t, SuspensionReason(""), r.WaitReason())
+		require.Nil(t, r.Topics())
+		_, ok := r.NextWakeAt()
+		require.False(t, ok)
+	})
+}
+
 func TestExecuteOrResumeNoCheckpointRunsFresh(t *testing.T) {
 	wf, err := New(Options{
 		Name: "eor-test",


### PR DESCRIPTION
## Summary

Add convenience accessors on `*ExecutionResult` so consumers don't have to write the same map-lookup-and-type-assert boilerplate at every call site.

### Output accessors

- `Output(key) (any, bool)` — raw lookup with presence flag.
- `OutputString(key) (string, bool)`
- `OutputInt(key) (int, bool)` — accepts `int`, `int32`, `int64`, `float32`, `float64` so JSON-decoded numbers (which come back as `float64`) work as expected.
- `OutputBool(key) (bool, bool)`
- `workflow.OutputAs[T](r, key) (T, bool)` — package-level generic for arbitrary types, including custom structs.

### Suspension accessors

- `WaitReason() SuspensionReason` — dominant reason or `""`.
- `Topics() []string` — union of waited-on signal topics, or `nil` if not suspended on a signal-wait.
- `NextWakeAt() (time.Time, bool)` — earliest wall-clock deadline across suspended branches, with a presence flag. Common use: `time.AfterFunc(time.Until(t), resumeFn)`.

All accessors are nil-safe on the receiver. Tests cover happy paths, type mismatches, missing keys, and nil receivers.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` passes (TestExecutionResultOutputHelpers, TestExecutionResultSuspensionHelpers added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)