### PR TITLE
PR13: documentation rewrite

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,260 @@
+# Migration to v1
+
+This document lists every breaking change between the pre-v1 API and
+v1, with before/after snippets. Pre-v1 had no compatibility promise,
+so the changes are listed by area rather than by deprecation tier —
+update everything in one pass.
+
+## 1. `Path` → `Branch` rename (PR1)
+
+Every public identifier that referred to a "path" through the step
+graph is now "branch."
+
+| Before                          | After                              |
+| ------------------------------- | ---------------------------------- |
+| `PathState`                     | `BranchState`                      |
+| `PathSnapshot`                  | `BranchSnapshot`                   |
+| `JoinConfig.Paths`              | `JoinConfig.Branches`              |
+| `JoinConfig.PathMappings`       | `JoinConfig.BranchMappings`        |
+| `Output.Path`                   | `Output.Branch`                    |
+| `Edge.PathName`                 | `Edge.BranchName`                  |
+| `Checkpoint.PathStates`         | `Checkpoint.BranchStates`          |
+| `Context.PathID()`              | `Context.BranchID()`               |
+| `PauseBranch` / `UnpauseBranch` | unchanged (already used "branch")  |
+
+Checkpoints written by older versions cannot be loaded — the JSON
+field name `path_states` does not match `branch_states`. Re-run any
+in-flight executions from scratch, or convert by hand.
+
+## 2. Surface shrink (PR2)
+
+The following types and methods were removed because they had a
+single internal caller, no test coverage, or duplicated functionality
+already exposed elsewhere. Most consumers won't notice.
+
+If you were calling any of these directly, see the v1 source for the
+replacement; the engine still does the work, it's just no longer
+exposed.
+
+## 3. Validation phase 1 + step kinds + StartAt (PR3)
+
+`workflow.New` now performs structural validation up front and
+returns a `*ValidationError` containing every problem it finds.
+Previously, structural problems surfaced as runtime errors during
+execution.
+
+- Steps must have exactly one *kind* (Activity, Join, WaitSignal,
+  Sleep, or Pause). Mixing kinds returns `ErrInvalidStepKind`.
+- Modifier fields (Retry, Catch) are valid only on Activity-kind
+  steps. Attaching them to a Sleep or Join now returns
+  `ErrInvalidModifier`.
+- `Options.StartAt` lets you pin the start step explicitly. Without
+  it, the first step in `Options.Steps` is still the start.
+
+```go
+// Before — runtime failure if Sleep step had Retry attached
+wf, _ := workflow.New(workflow.Options{Steps: steps})
+exec.Run(ctx) // panics or fails mid-flight
+
+// After — workflow.New returns a ValidationError describing all
+// problems before any execution starts.
+wf, err := workflow.New(workflow.Options{Steps: steps})
+if err != nil {
+    var ve *workflow.ValidationError
+    if errors.As(err, &ve) {
+        for _, p := range ve.Problems { /* report */ }
+    }
+}
+```
+
+## 4. ActivityRegistry, functional options, single Execute (PR4)
+
+`NewExecution` now takes a workflow, an `ActivityRegistry`, and
+functional options. The `ExecutionOptions` struct is gone. The
+multiple Run/Execute method variants collapsed into a single
+`Execute(ctx, ...ExecuteOption)`.
+
+```go
+// Before
+exec, _ := workflow.NewExecution(workflow.ExecutionOptions{
+    Workflow:   wf,
+    Activities: []workflow.Activity{a, b, c},
+    Logger:     logger,
+})
+exec.Run(ctx)
+
+// After
+reg := workflow.NewActivityRegistry()
+reg.MustRegister(a, b, c)
+exec, _ := workflow.NewExecution(wf, reg, workflow.WithLogger(logger))
+result, _ := exec.Execute(ctx)
+```
+
+`Run` is gone — `Execute` returns `(*ExecutionResult, error)` and is
+the single entry point. Resume is a functional option:
+`exec.Execute(ctx, workflow.ResumeFrom(priorID))`.
+
+`NewActivityFunction` and `NewTypedActivityFunction` are renamed to
+`ActivityFunc` and `TypedActivityFunc`. The internal struct types
+were unexported.
+
+## 5. Binding validation in NewExecution (PR5)
+
+`NewExecution` now binds the workflow against the registry and the
+script compiler, surfacing missing activities, bad templates, and
+bad expressions as `ValidationProblem`s on a `*ValidationError`
+before any execution begins.
+
+```go
+// Before — missing activity surfaced at runtime
+exec, _ := workflow.NewExecution(workflow.ExecutionOptions{Workflow: wf, Activities: nil})
+exec.Run(ctx) // fails on first step that needed an activity
+
+// After — caught at construction
+_, err := workflow.NewExecution(wf, workflow.NewActivityRegistry())
+// err is *ValidationError with ErrUnknownActivity problems for
+// every step that referenced an unregistered activity
+```
+
+## 6. Context becomes idiomatic Go (PR6)
+
+`workflow.Context` now embeds `context.Context`. Pass it directly to
+any stdlib API that takes a context — no `.Std()` method, no manual
+unwrapping. Custom implementations of `Context` should embed
+`context.Context` too.
+
+```go
+// Before
+func myActivity(ctx workflow.Context, p Params) (any, error) {
+    req, _ := http.NewRequestWithContext(ctx.Std(), "GET", url, nil)
+    return http.DefaultClient.Do(req)
+}
+
+// After
+func myActivity(ctx workflow.Context, p Params) (any, error) {
+    req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+    return http.DefaultClient.Do(req)
+}
+```
+
+## 7. Checkpoint stable wire format (PR7)
+
+`Checkpoint` is now versioned. `CheckpointSchemaVersion` is `1` and
+is set on every saved checkpoint. Readers must reject any checkpoint
+with a higher schema version than they understand. The JSON tag on
+every field is part of the stable format.
+
+See `Checkpoint`'s godoc for the round-trip contract and the
+load-bearing fields list.
+
+## 8. Single template syntax (PR8)
+
+`${...}` is the only template form. The `$(...)` "type-preserving"
+syntax is gone. When a parameter value is a single `${...}` covering
+the whole trimmed string, the result preserves its native Go type
+automatically; otherwise the template is interpolated into a string.
+
+```go
+// Before
+Parameters: map[string]any{
+    "message": "Counter is ${state.counter}",       // string
+    "value":   "$(state.counter)",                  // typed
+}
+
+// After — the difference is automatic from context
+Parameters: map[string]any{
+    "message": "Counter is ${state.counter}",       // string (interpolated)
+    "value":   "${state.counter}",                  // typed (whole-value)
+}
+```
+
+Edge conditions and `each.Items` are raw expressions — no `${...}`
+or `$(...)` wrapper:
+
+```go
+Condition: "state.counter <= inputs.max_count"
+Each: &workflow.Each{Items: "state.users"}
+```
+
+## 9. Activities tier split + naming (PR9)
+
+The `activities/` tree is now split by guarantee level:
+
+| Activity              | Was                  | Now                       |
+| --------------------- | -------------------- | ------------------------- |
+| `print` / `time` / `json` / `random` / `fail` | `activities/` | `activities/` (unchanged) |
+| `http`                | `activities/`        | `activities/httpx/`       |
+| `shell` / `file`      | `activities/`        | `activities/contrib/`     |
+| `wait`                | `activities/`        | **deleted**               |
+
+```go
+// Before
+import "github.com/deepnoodle-ai/workflow/activities"
+
+reg.MustRegister(activities.NewHTTPActivity(), activities.NewShellActivity())
+
+// After
+import (
+    "github.com/deepnoodle-ai/workflow/activities/contrib"
+    "github.com/deepnoodle-ai/workflow/activities/httpx"
+)
+
+reg.MustRegister(httpx.NewHTTPActivity(), contrib.NewShellActivity())
+```
+
+`activities.NewWaitActivity` is gone. Use a `Sleep` step for durable
+waits (survives restarts), or write a one-line activity that calls
+`time.Sleep` for in-process delays.
+
+`PrintActivity` now wraps an `io.Writer`. `NewPrintActivity()`
+defaults to `os.Stdout`; `NewPrintActivityTo(w)` injects a custom
+writer.
+
+All `float64`-second timeouts are now `time.Duration`. Affects
+`httpx.HTTPInput.Timeout`, `contrib.ShellInput.Timeout`, and
+`activities.ChildWorkflowInput.Timeout`.
+
+## 10. Child workflow fixes (PR10)
+
+- `ChildWorkflowSpec.Sync` deleted. Choose sync vs async at the
+  call site by invoking `ExecuteSync` or `ExecuteAsync`.
+- `ChildWorkflowResult.Error` dropped. The execution error is the
+  second return value; consult that instead.
+- `ChildWorkflowExecutorOptions.CleanupTimeout` added. Default `1h`
+  (was a hardcoded 5 minutes). Negative disables eviction entirely.
+- The bundled `workflow.child` activity is sync-only. Drop the
+  `"sync": true` parameter from existing workflows. Consumers
+  needing fire-and-forget should write a custom activity that calls
+  `executor.ExecuteAsync` directly.
+
+`ExecuteAsync`'s godoc now spells out the in-process / non-durable
+contract: async children die with the parent process.
+
+## 11. Error model + completion hook (PR11)
+
+- `ClassifyError` no longer substring-matches `"timeout"`. Real
+  timeouts must wrap `context.DeadlineExceeded` or
+  `workflow.ErrWaitTimeout`.
+- `context.Canceled` is no longer classified as a timeout — it
+  represents caller-initiated cancellation, not deadline expiry.
+- `WorkflowError.Error()` now prefixes `workflow:`.
+- All root-package error sentinels are prefixed with `workflow:`.
+- `WorkflowError.Details` is documented as non-roundtrip across
+  Checkpoint persistence; wrap your own error type if you need
+  structured details to survive resume.
+
+If you were comparing error strings, they now contain the
+`workflow:` prefix. Switch to `errors.Is` / `errors.As` for sentinel
+checks.
+
+## 12. ExecutionResult helpers (PR12)
+
+Additive only — no breaking change. New convenience accessors on
+`*ExecutionResult`:
+
+- `Output(key)`, `OutputString(key)`, `OutputInt(key)`,
+  `OutputBool(key)`
+- `WaitReason()`, `Topics()`, `NextWakeAt()`
+- Generic helper `workflow.OutputAs[T](r, key)`
+
+All accessors are nil-safe on the receiver.

--- a/README.md
+++ b/README.md
@@ -1,36 +1,33 @@
 # Workflow
 
-An easy-to-use workflow automation library for Go. Supports conditional
-branching, parallel execution, expression-driven templating, and execution
-checkpointing.
+A Go library for defining and executing multi-step processes as
+directed graphs. Conditional branching, parallel execution,
+expression-driven templating, durable checkpointing, and
+suspend/resume on signals or wall-clock waits.
 
-Think of it like a lightweight hybrid of Temporal and AWS Step Functions.
+Think of it like a lightweight hybrid of Temporal and AWS Step
+Functions, with everything that doesn't belong inside an execution
+engine pushed out to interfaces consumers implement.
 
-Edge conditions and `${...}` parameter templates are evaluated
-by [`github.com/deepnoodle-ai/expr`](https://github.com/deepnoodle-ai/expr),
-a small zero-dependency expression evaluator that accepts a Go-like
-subset of expression syntax. It is the only external dependency of the
-root module.
+Edge conditions and `${...}` parameter templates are evaluated by
+[`github.com/deepnoodle-ai/expr`](https://github.com/deepnoodle-ai/expr),
+a small zero-dependency expression evaluator with a Go-like syntax.
+It is the only external dependency of the root module.
 
-## Main Concepts
+## Main concepts
 
-| Concept | Description |
-|---------|-------------|
-| **Workflow**   | A repeatable process defined as a directed graph of steps |
-| **Steps**      | Individual nodes in the workflow graph |
-| **Activities** | Functions that perform the actual work |
-| **Edges**      | Define flow between steps |
-| **Execution**  | A single run of a workflow |
-| **State**      | Shared mutable state that persists for the duration of an execution |
+| Concept        | Description                                                                            |
+| -------------- | -------------------------------------------------------------------------------------- |
+| **Workflow**   | A repeatable process defined as a directed graph of steps                              |
+| **Step**       | A node in the graph — runs an activity, joins branches, sleeps, waits, or pauses      |
+| **Activity**   | A function that performs the actual work                                               |
+| **Edge**       | Defines flow between steps, optionally guarded by a condition                          |
+| **Execution** | A single run of a workflow, with its own state                                         |
+| **Branch**     | An independent execution thread with its own copy of state                             |
+| **State**      | Branch-local mutable variables that activities read and write                          |
+| **Runner**     | Production entry point that composes heartbeat, timeout, resume, and completion hooks |
 
-### How They Work Together
-
-**Workflows** define **Steps** that execute **Activities**. An **Execution** is
-a single run of a workflow. When a step finishes, its outgoing **Edges** are
-evaluated and the next step(s) are selected based on any associated conditions.
-The **State** may be read and written to by the activities.
-
-## Quick Example
+## Quick example
 
 ```go
 package main
@@ -45,18 +42,17 @@ import (
 )
 
 func main() {
-
 	attempt := 0
 
-	myOperation := func(ctx workflow.Context, input map[string]any) (string, error) {
+	myOperation := func(ctx workflow.Context, _ map[string]any) (string, error) {
 		attempt++
-		if attempt < 3 { // Simulated failure
+		if attempt < 3 {
 			return "", fmt.Errorf("service is temporarily unavailable")
 		}
 		return "SUCCESS", nil
 	}
 
-	w, err := workflow.New(workflow.Options{
+	wf, err := workflow.New(workflow.Options{
 		Name: "demo",
 		Steps: []*workflow.Step{
 			{
@@ -70,7 +66,7 @@ func main() {
 				Name:     "Finish",
 				Activity: "print",
 				Parameters: map[string]any{
-					"message": "🎉 Workflow completed successfully! Result: ${state.result}",
+					"message": "Workflow completed. Result: ${state.result}",
 				},
 			},
 		},
@@ -79,19 +75,56 @@ func main() {
 		log.Fatal(err)
 	}
 
-	execution, err := workflow.NewExecution(workflow.ExecutionOptions{
-		Workflow: w,
-		Activities: []workflow.Activity{
-			workflow.TypedActivityFunc("my_operation", myOperation),
-			activities.NewPrintActivity(),
-		},
-	})
+	reg := workflow.NewActivityRegistry()
+	reg.MustRegister(
+		workflow.TypedActivityFunc("my_operation", myOperation),
+		activities.NewPrintActivity(),
+	)
+
+	exec, err := workflow.NewExecution(wf, reg)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	if err := execution.Run(context.Background()); err != nil {
+	runner := workflow.NewRunner()
+	result, err := runner.Run(context.Background(), exec)
+	if err != nil {
 		log.Fatal(err)
+	}
+	if !result.Completed() {
+		log.Fatalf("execution did not complete: %v", result.Error)
+	}
+
+	if got, ok := result.OutputString("result"); ok {
+		fmt.Println("final result:", got)
 	}
 }
 ```
+
+The `Runner` is the recommended entry point for production code. It
+composes heartbeating, default timeouts, resume-from-checkpoint, and
+completion hooks. For one-shot scripts and tests, calling
+`exec.Execute(ctx)` directly is fine.
+
+## Going to production
+
+The library is a pure execution engine. Storage, scheduling, signal
+delivery, and worker leasing are the consumer's responsibility — the
+library defines interfaces (`Checkpointer`, `StepProgressStore`,
+`ActivityLogger`, `SignalStore`, `WorkflowRegistry`) and you wire
+your own backends. The bundled `MemoryCheckpointer` and
+`FileCheckpointer` are for development only.
+
+See [`docs/production_checklist.md`](docs/production_checklist.md)
+for the full punch list, and [`docs/suspension.md`](docs/suspension.md)
+for the suspend / resume / replay-safety contract.
+
+## Reference
+
+- [`llms.txt`](llms.txt) — full API reference, including the JSON
+  workflow format and the script-compiler interface.
+- [`MIGRATION.md`](MIGRATION.md) — every breaking change between
+  pre-v1 and v1, with before/after snippets.
+- [`examples/`](examples/) — runnable example programs covering
+  branching, joins, retries, signals, sleeps, child workflows, and
+  more.

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -22,7 +22,7 @@ const CheckpointSchemaVersion = 1
 // checkpointing, resuming, and inspecting running or dormant
 // executions.
 //
-// Round-trip contract:
+// # Round-trip contract
 //
 //   - The engine marshals Checkpoint to JSON via encoding/json.
 //   - Consumers may swap a different encoder for storage, but MUST
@@ -35,6 +35,30 @@ const CheckpointSchemaVersion = 1
 // The JSON tag on every field is part of the stable format. Adding a
 // field is always safe (zero value on load from an older writer);
 // renaming or removing a field is a schema break.
+//
+// # Load-bearing fields
+//
+// The orchestrator's resume logic depends on these fields surviving
+// the round-trip; a custom encoder that drops them will silently
+// corrupt resumed executions:
+//
+//   - BranchState.Variables — branch-local state that activities
+//     read and write. Without it, resumed branches restart from a
+//     blank state.
+//   - BranchState.Wait — the active wait/sleep state. Without it,
+//     a branch that was hard-suspended on a signal-wait or sleep
+//     can't be re-parked on resume; the engine treats it as a fresh
+//     advance.
+//   - BranchState.PauseRequested — whether the branch was paused
+//     by an operator or a Pause step. Without it, a paused branch
+//     resumes as if it had never been paused.
+//   - BranchState.ActivityHistory / ActivityHistoryStep — the
+//     per-step replay cache used by Context.History. Without it,
+//     activities re-execute side effects on every wait-unwind
+//     replay.
+//
+// All other fields are advisory or recoverable from the workflow
+// definition.
 type Checkpoint struct {
 	// SchemaVersion is the wire-format version. Set to
 	// CheckpointSchemaVersion by the engine on every save.

--- a/context.go
+++ b/context.go
@@ -49,10 +49,61 @@ type Context interface {
 	// StepName returns the name of the currently executing step.
 	StepName() string
 
-	// Wait durably waits for a signal on the given topic. See the
-	// package-level documentation on the wait behaviour, replay
-	// safety, and the multi-wait pattern in
-	// planning/prds/002-signals-waits-pausing.md.
+	// Wait durably parks the current branch until a signal is
+	// delivered to topic, or until timeout elapses.
+	//
+	// # Behavior
+	//
+	// On the first invocation in a step, Wait registers a wait
+	// state against the branch's checkpoint and returns a sentinel
+	// error (waitUnwind) that the engine catches at the activity
+	// boundary. The activity goroutine exits, the orchestrator
+	// persists a checkpoint with BranchState.Wait set, and the
+	// execution ends with Status=ExecutionStatusSuspended.
+	//
+	// When the consumer delivers a signal to the topic via the
+	// execution's SignalStore and calls Resume, the engine re-enters
+	// the same activity. On the second invocation, Wait sees the
+	// delivered payload and returns it to the caller as the first
+	// return value.
+	//
+	// # Replay safety
+	//
+	// Activities that call Wait MUST be replay-safe: any side
+	// effect that runs before the Wait call will run again on the
+	// resumed invocation. Use Context.History to memoize expensive
+	// or non-idempotent work. The shape is:
+	//
+	//	func(ctx Context, p Params) (any, error) {
+	//	    result, _ := workflow.RecordOrReplay(ctx.History(), "key", func() (T, error) {
+	//	        // side-effecting work runs once, replays from cache
+	//	    })
+	//	    payload, err := ctx.Wait("topic", timeout)
+	//	    // post-wait code runs once after the signal arrives
+	//	}
+	//
+	// # Deadline behavior
+	//
+	// timeout is wall-clock and starts ticking from when Wait is
+	// first called; the engine records an absolute deadline at
+	// register time. On resume, the engine recomputes the remaining
+	// time against the original deadline; a wait that has already
+	// expired wakes immediately with ErrWaitTimeout.
+	//
+	// Routing a timeout to a step (instead of failing the activity)
+	// requires a declarative WaitSignalConfig with OnTimeout set;
+	// the imperative Context.Wait always surfaces ErrWaitTimeout to
+	// the caller.
+	//
+	// # Custom Context implementations
+	//
+	// Test doubles or alternative Context implementations MUST
+	// forward Wait to the engine's underlying implementation. Wait
+	// depends on engine-internal branch state — the checkpoint, the
+	// wait registry, the resume path — and a custom Context that
+	// returns nil/error from Wait without touching that state will
+	// silently break replay semantics. The workflowtest package is
+	// the supported pattern for unit tests.
 	Wait(topic string, timeout time.Duration) (any, error)
 	// History returns the per-activity-invocation persisted cache.
 	// Returns a process-local, non-persistent cache if called outside

--- a/docs/production_checklist.md
+++ b/docs/production_checklist.md
@@ -1,0 +1,102 @@
+# Production checklist
+
+The library is a pure execution engine: it runs workflows in-process
+and provides interfaces for the things it doesn't own. Going to
+production means wiring durable storage, observability, and
+operational hygiene around it. This is the punch list.
+
+## Storage
+
+- [ ] **Checkpointer** is wired to durable storage (Postgres, Redis,
+  S3, etc.). The bundled `MemoryCheckpointer` and `FileCheckpointer`
+  are dev-only.
+- [ ] **StepProgressStore** is wired if the consumer wants
+  step-level progress visibility outside the activity log.
+- [ ] **ActivityLogger** is wired to whatever activity log store the
+  consumer uses. The bundled `FileActivityLogger` is dev-only.
+- [ ] **WorkflowRegistry** is loaded with every workflow definition
+  the worker needs to run, at startup. Late registration is not
+  supported.
+- [ ] **SignalStore** is durable if the consumer uses `Wait` or
+  `WaitSignal`. In-memory signal stores lose pending signals on
+  process restart.
+- [ ] Checkpoint round-trip is tested against the consumer's
+  encoder. The library uses `encoding/json`; if you swap encoders,
+  ensure every `BranchState` field — especially `PauseRequested`,
+  `Wait`, `Variables`, `ActivityHistory` — survives the round trip.
+  See [`Checkpoint`](../checkpoint.go) godoc.
+
+## Execution
+
+- [ ] **Runner** (not bare `Execution.Execute`) is the production
+  entry point. The Runner composes heartbeat, default timeout,
+  resume, and the completion hook.
+- [ ] `WithDefaultTimeout` is set on the Runner, or `WithRunTimeout`
+  on every `Run` call. Untimed executions can wedge a worker
+  indefinitely.
+- [ ] `WithHeartbeat` is wired if the consumer uses worker leases.
+  The heartbeat func should refresh the lease and return an error
+  on lease loss; the Runner cancels the execution context, and the
+  workflow aborts cooperatively.
+- [ ] `WithCompletionHook` is wired if the consumer triggers
+  follow-up workflows from completed executions. Returning an error
+  from the hook does not change `result.Status`; the partial
+  follow-up list is still attached to `result.FollowUps`.
+
+## Activity authoring
+
+- [ ] Activities are **idempotent**. The engine retries on
+  classified errors and replays on wait-unwind; an activity that
+  charges a credit card without an idempotency key will charge it
+  twice.
+- [ ] Activities that call `Context.Wait` use `Context.History` /
+  `RecordOrReplay` to memoize side effects. See
+  [`docs/suspension.md`](suspension.md) for the replay-safety
+  contract.
+- [ ] Activities propagate `ctx` to every blocking call (HTTP,
+  database, child workflows). The engine cancels the context on
+  heartbeat failure or caller cancel — activities that ignore it
+  hang the worker.
+- [ ] Errors that should NOT be retried are surfaced as a
+  `WorkflowError` with `Type: workflow.ErrorTypeFatal`. Default
+  classification routes to `ErrorTypeActivityFailed`, which IS
+  retried by `RetryConfig{ErrorEquals: ["activity_failed"]}`.
+
+## Suspension and resume
+
+- [ ] The consumer subscribes to the `Suspension.Topics` slice for
+  every signal-suspended execution and routes incoming signals to
+  the right execution.
+- [ ] The consumer schedules a wall-clock resume at
+  `Suspension.WakeAt` for every sleep-suspended execution.
+- [ ] Resume uses `runner.Run(ctx, exec, workflow.WithResumeFrom(priorID))`
+  on a fresh `Execution` built from the same workflow + registry.
+- [ ] Stale checkpoints (older than the consumer's TTL policy) are
+  garbage-collected from the checkpointer. The library does not
+  manage retention.
+
+## Observability
+
+- [ ] `WithLogger` (or the Runner's `WithRunnerLogger`) is set to a
+  structured logger. The default is a discard logger.
+- [ ] An ActivityLogger is wired so per-activity inputs / outputs /
+  errors are auditable. Without it, debugging a failed execution
+  means re-running it.
+- [ ] StepProgressStore is wired if the consumer needs sub-step
+  progress in dashboards (e.g., a long-running activity that
+  reports `ctx.ReportProgress`).
+
+## Worker hygiene
+
+- [ ] Each worker process holds a **lease** on the executions it is
+  running and refreshes via the Runner heartbeat. Two workers
+  running the same execution at the same time will both write
+  checkpoints and the last writer wins.
+- [ ] The worker's shutdown path drains in-flight executions
+  cleanly: cancel the parent context, wait for `runner.Run` calls
+  to return, then exit. The engine writes a final checkpoint on
+  context cancel.
+- [ ] Workflow definitions and activity registrations are immutable
+  per worker version. Hot-swapping a workflow under a running
+  execution will produce undefined behavior; deploy a new worker
+  version, drain the old one.

--- a/docs/suspension.md
+++ b/docs/suspension.md
@@ -1,0 +1,138 @@
+# Suspension model
+
+A workflow execution can end in three states that are not "completed"
+or "failed": **suspended**, **paused**, and **canceled**. Suspended
+and paused are dormant — the execution is durable, the consumer is
+expected to schedule a resume. Canceled is terminal.
+
+This document covers suspended and paused. Together they're the
+"needs resume" cases, and `ExecutionResult.NeedsResume()` collapses
+both into one boolean.
+
+## The three reasons
+
+| Reason                             | Trigger                                       | What advances it                                  |
+| ---------------------------------- | --------------------------------------------- | ------------------------------------------------- |
+| `SuspensionReasonWaitingSignal`    | `Context.Wait` or a `WaitSignal` step         | A signal delivered to the topic, then `Resume`    |
+| `SuspensionReasonSleeping`         | A `Sleep` step                                | Wall-clock time reaches `WakeAt`, then `Resume`   |
+| `SuspensionReasonPaused`           | `PauseBranch` call or a `Pause` step          | `UnpauseBranch` (or in-checkpoint variant), then `Resume` |
+
+The first two are **suspended** (`Status = ExecutionStatusSuspended`).
+The third is **paused** (`Status = ExecutionStatusPaused`). Both ride
+through `Suspension *SuspensionInfo` on the result; `WaitReason()`,
+`Topics()`, and `NextWakeAt()` are convenience accessors.
+
+## Lifecycle
+
+```
+                  +----------+
+   Execute(ctx) ->| Running  |--success-> Completed
+                  |          |--failure-> Failed
+                  +----+-----+
+                       |
+                       | Wait/Sleep/Pause
+                       v
+                  +----------+
+                  | Dormant  |   <-- checkpoint persisted, goroutines exited
+                  +----+-----+
+                       |
+                       | external trigger arrives
+                       v
+                  +----------+
+                  | Resume   |
+                  +----+-----+
+                       |
+                       v
+                  ... (loop)
+```
+
+The dormant state is **fully durable**: every variable, every wait
+deadline, every pause flag is in the checkpoint. The process can
+restart, the resume can run on a different worker, and the execution
+picks up where it left off.
+
+## Replay-safety contract
+
+The single most important rule for activities that call `Wait`:
+
+> Code that runs **before** `Wait` will run again on resume.
+
+The wait sentinel triggers an unwind that the engine catches at the
+activity boundary. The activity goroutine exits, the checkpoint is
+persisted, and the execution ends suspended. When `Resume` runs, the
+engine re-enters the same step and the same activity. Everything in
+the activity body that ran before the `Wait` runs again.
+
+Use `Context.History` (specifically `RecordOrReplay`) to memoize
+side effects:
+
+```go
+func myActivity(ctx workflow.Context, p Params) (any, error) {
+    // Runs once. On replay, returns the cached value from the
+    // checkpoint without re-executing the closure.
+    requestID, _ := workflow.RecordOrReplay(ctx.History(), "request_id", func() (string, error) {
+        return externalAPI.CreateRequest(ctx, p)
+    })
+
+    // Suspends here. On resume, externalAPI.CreateRequest is NOT
+    // called again — `requestID` comes from the cache.
+    payload, err := ctx.Wait("callback-" + requestID, 24 * time.Hour)
+    if err != nil {
+        return nil, err
+    }
+
+    // Runs only once, after the signal arrives.
+    return processPayload(payload), nil
+}
+```
+
+The `History` cache is per-step: it lives on `BranchState.ActivityHistory`
+and is cleared when the step advances past the activity. There is no
+cross-step leakage.
+
+## Scheduling a resume from `WakeAt`
+
+```go
+result, _ := runner.Run(ctx, exec)
+
+if result.NeedsResume() {
+    if wakeAt, ok := result.NextWakeAt(); ok {
+        // Wall-clock resume — sleeps and signal-wait timeouts.
+        time.AfterFunc(time.Until(wakeAt), func() {
+            // Build a fresh execution from the checkpointer and
+            // call runner.Run with WithResumeFrom(exec.ID()).
+        })
+    }
+
+    for _, topic := range result.Topics() {
+        // Signal-wait resume — register a listener that calls
+        // signalStore.Deliver(topic, payload) and then schedules a
+        // resume of exec.ID().
+    }
+}
+```
+
+Wall-clock and signal triggers are not mutually exclusive — a single
+execution can be parked on a signal *with* a timeout. The `Topics()`
+slice and the `NextWakeAt()` deadline are both populated. Whichever
+trigger fires first wins; the other becomes a no-op when the
+execution next checkpoints.
+
+## Dominant reason precedence
+
+When multiple branches are dormant for different reasons, the
+result reports a single dominant reason via `Suspension.Reason`.
+The full per-branch breakdown is in `Suspension.SuspendedBranches`.
+
+The precedence rule, from highest to lowest:
+
+1. `SuspensionReasonPaused` — operator intent always wins. If any
+   branch was explicitly paused, the execution reports paused.
+2. `SuspensionReasonWaitingSignal` — outranks sleep because a
+   signal can resolve faster than a wall-clock wake.
+3. `SuspensionReasonSleeping` — only the dominant reason if every
+   dormant branch is sleeping.
+
+The dominant-reason rule is a hint to the consumer: "schedule the
+right kind of resume." Consumers that need to handle multiple
+reasons in one execution should iterate `SuspendedBranches`.

--- a/llms.txt
+++ b/llms.txt
@@ -1,15 +1,17 @@
 # Workflow
 
-Workflow is a Go library for defining and executing multi-step processes as
-directed graphs. It supports conditional branching, parallel execution,
-path-local state, checkpointing, retry with backoff, error handling, child
-workflows, and expression-driven edge conditions and parameter templates
-via the bundled `github.com/deepnoodle-ai/expr` evaluator. Go 1.26+.
+Workflow is a Go library for defining and executing multi-step
+processes as directed graphs. It supports conditional branching,
+parallel execution, branch-local state, durable checkpointing, retry
+with backoff, error handling, child workflows, and expression-driven
+edge conditions and parameter templates via the bundled
+`github.com/deepnoodle-ai/expr` evaluator. Go 1.26+.
 
 The root module has a single external dependency
 (`github.com/deepnoodle-ai/expr`). Consumers who want a different
 expression or scripting engine can implement the `script.Compiler`
-interface themselves and pass it via `ExecutionOptions.ScriptCompiler`.
+interface themselves and pass it via `WithScriptCompiler` on
+`NewExecution`.
 
 Think of it as a lightweight hybrid of Temporal and AWS Step Functions.
 
@@ -19,22 +21,23 @@ Install: `go get github.com/deepnoodle-ai/workflow`
 
 ## Core concepts
 
-- **Workflow** - a repeatable process defined as a directed graph of steps
-- **Step** - a node in the graph that executes an activity
-- **Activity** - a function that performs actual work
-- **Edge** - defines flow between steps, optionally with a condition
-- **Execution** - a single run of a workflow
-- **Path** - an independent execution thread with its own copy of state
-- **State** - path-local mutable variables accessible to activities
-- **Runner** - production entry point that composes heartbeat, timeout, resume, and hooks
+- **Workflow** — a repeatable process defined as a directed graph of steps
+- **Step** — a node in the graph; runs an activity, joins branches, sleeps, waits, or pauses
+- **Activity** — a function that performs the actual work
+- **Edge** — defines flow between steps, optionally with a condition
+- **Execution** — a single run of a workflow
+- **Branch** — an independent execution thread with its own copy of state
+- **State** — branch-local mutable variables accessible to activities
+- **Runner** — production entry point that composes heartbeat, timeout, resume, and completion hooks
 
-Workflows define Steps that execute Activities. An Execution runs the workflow.
-When a step finishes, its outgoing Edges are evaluated and the next step(s) are
-selected based on conditions. Each execution path owns its state independently.
-When paths branch, child paths receive a copy of the parent's state and evolve
+Workflows define Steps that execute Activities. An Execution runs the
+workflow. When a step finishes, its outgoing Edges are evaluated and
+the next step(s) are selected based on conditions. Each branch owns
+its state independently — when a step's outgoing edges fan out, child
+branches receive a deep copy of the parent's state and evolve
 independently.
 
-## Quick example
+## Quick example with Runner
 
 ```go
 w, _ := workflow.New(workflow.Options{
@@ -58,19 +61,32 @@ w, _ := workflow.New(workflow.Options{
 })
 
 // Templates like ${state.result} and edge Condition expressions are
-// evaluated by the default expr-backed compiler when
-// ExecutionOptions.ScriptCompiler is nil. Override it only if you want
-// a different engine.
-execution, _ := workflow.NewExecution(workflow.ExecutionOptions{
-    Workflow: w,
-    Activities: []workflow.Activity{
-        workflow.TypedActivityFunc("my_operation", myFunc),
-        activities.NewPrintActivity(),
-    },
-})
+// evaluated by the default expr-backed compiler. Override via
+// WithScriptCompiler on NewExecution if you want a different engine.
+reg := workflow.NewActivityRegistry()
+reg.MustRegister(
+    workflow.TypedActivityFunc("my_operation", myFunc),
+    activities.NewPrintActivity(),
+)
 
-execution.Run(context.Background())
+exec, _ := workflow.NewExecution(w, reg)
+
+// Runner is the recommended production entry point. It composes
+// heartbeating, default timeout, resume-from-checkpoint, and the
+// completion hook around exec.Execute.
+runner := workflow.NewRunner(workflow.WithDefaultTimeout(5 * time.Minute))
+result, err := runner.Run(context.Background(), exec)
+if err != nil {
+    log.Fatal(err) // infrastructure failure (heartbeat, timeout, ...)
+}
+if !result.Completed() {
+    log.Fatalf("workflow failed: %v", result.Error)
+}
+fmt.Println(result.Outputs)
 ```
+
+For one-shot scripts and tests, calling `exec.Execute(ctx)` directly
+without a Runner is fine.
 
 ## Workflow definition
 
@@ -94,8 +110,8 @@ consumers that prefer YAML, TOML, etc. wire that themselves. See
 `Input` fields: Name, Type, Description, Default. An input is required when
 Default is nil.
 
-`Output` fields: Name, Variable (state variable to extract), Path (which
-execution path to extract from, defaults to "main"), Description.
+`Output` fields: Name, Variable (state variable to extract), Branch
+(which branch to extract from, defaults to "main"), Description.
 
 ## Steps
 
@@ -103,20 +119,30 @@ execution path to extract from, defaults to "main"), Description.
 &workflow.Step{
     Name:                 "Process Data",
     Description:          "Optional description",
-    Activity:             "process",             // activity name to execute
-    Parameters:           map[string]any{...},   // passed to the activity
-    Store:                "state.result",         // store activity output in this variable
-    Each:                 &workflow.Each{...},    // loop over items
-    Join:                 &workflow.JoinConfig{}, // wait for paths to converge
-    Next:                 []*workflow.Edge{...},  // outgoing edges
+    Activity:             "process",                  // activity name to execute
+    Parameters:           map[string]any{...},        // passed to the activity
+    Store:                "result",                   // store activity output in this branch variable
+    Each:                 &workflow.Each{...},        // loop over items
+    Join:                 &workflow.JoinConfig{...},  // wait for branches to converge
+    WaitSignal:           &workflow.WaitSignalConfig{...}, // park until a signal arrives
+    Sleep:                &workflow.SleepConfig{...}, // durably sleep
+    Pause:                &workflow.PauseConfig{...}, // park until an operator unpauses
+    Next:                 []*workflow.Edge{...},      // outgoing edges
     EdgeMatchingStrategy: workflow.EdgeMatchingFirst, // or EdgeMatchingAll (default)
     Retry:                []*workflow.RetryConfig{...},
     Catch:                []*workflow.CatchConfig{...},
 }
 ```
 
-A step with no Next edges is a terminal step. The first step in the Steps
-slice is the start step.
+A step has exactly one *kind*: Activity, Join, WaitSignal, Sleep, or
+Pause. workflow.New rejects any step that sets more than one with
+ErrInvalidStepKind. Modifier fields (Retry, Catch) are valid only on
+Activity-kind steps; attaching them elsewhere returns
+ErrInvalidModifier.
+
+A step with no Next edges is a terminal step. The first step in
+Options.Steps is the start step unless Options.StartAt names a
+different one.
 
 ## Edges and branching
 
@@ -128,44 +154,44 @@ Next: []*workflow.Edge{
 }
 ```
 
-Edge fields: Step (target step name), Condition (script expression
-evaluated by the configured script engine), Path (optional name for the
-branched execution path).
+Edge fields: Step (target step name), Condition (raw expression
+evaluated by the configured script engine), BranchName (optional name
+for the branch created when this edge is followed; empty means
+"continue on the current branch").
 
-When multiple edges match, each creates a new execution path that runs in
-parallel. Use `EdgeMatchingStrategy: workflow.EdgeMatchingFirst` to follow
-only the first matching edge.
+When multiple edges match, each creates a new branch that runs in
+parallel. Use `EdgeMatchingStrategy: workflow.EdgeMatchingFirst` to
+follow only the first matching edge.
 
-Named paths enable parallel execution and later joining:
+Named branches enable parallel execution and later joining:
 
 ```go
 Next: []*workflow.Edge{
     {Step: "ProcessA", BranchName: "a"},
     {Step: "ProcessB", BranchName: "b"},
-    {Step: "Join", BranchName: "final"},
 }
 ```
 
-## Joining paths
+## Joining branches
 
 ```go
 &workflow.Step{
     Name: "join",
     Join: &workflow.JoinConfig{
-        Branches: []string{"a", "b"},           // wait for these paths
+        Branches: []string{"a", "b"},        // wait for these branches
         BranchMappings: map[string]string{
             "a.result_a": "valueA",          // extract specific variable
             "b.result_b": "valueB",
-            // or store entire path state: "a": "results.pathA"
+            // or store entire branch state: "a": "results.branchA"
         },
     },
     Next: []*workflow.Edge{{Step: "Continue"}},
 }
 ```
 
-JoinConfig fields: Paths (which paths to wait for), Count (number of paths
-to wait for, 0 = all), BranchMappings (where to store path data using dot
-notation for both source and destination).
+JoinConfig fields: Branches (which branches to wait for), Count
+(number of branches to wait for; 0 = all), BranchMappings (where to
+store branch data using dot notation for both source and destination).
 
 ## Retry
 
@@ -257,29 +283,35 @@ workflow.NewTypedActivity(myActivityImpl)
 
 ## Context
 
-Activities receive `workflow.Context`, which embeds `context.Context` and
-provides state access:
+Activities receive `workflow.Context`, which embeds `context.Context`
+so it can be passed directly to any stdlib API that takes a context:
 
 ```go
 type Context interface {
     context.Context
-    VariableContainer  // SetVariable, GetVariable, DeleteVariable, ListVariables
 
-    ListInputs() []string
-    GetInput(key string) (value any, exists bool)
-    GetLogger() *slog.Logger
-    GetCompiler() script.Compiler
-    GetBranchID() string
-    GetStepName() string
+    Get(key string) (any, bool)
+    Set(key string, value any)
+    Delete(key string)
+    Variables() map[string]any
+    Inputs() map[string]any
+    Logger() *slog.Logger
+    Compiler() script.Compiler
+    BranchID() string
+    StepName() string
+
+    // Wait durably parks the branch on a signal topic. See the
+    // Signals, waits, and pausing section below.
+    Wait(topic string, timeout time.Duration) (any, error)
+    History() *History
+    ReportProgress(detail ProgressDetail)
 }
 ```
 
-Context helpers:
+Use the embedded `context.Context` directly — no `.Std()` method:
+
 ```go
-workflow.WithTimeout(ctx, 10*time.Second)  // returns (Context, CancelFunc)
-workflow.WithCancel(ctx)                   // returns (Context, CancelFunc)
-workflow.VariablesFromContext(ctx)          // returns map[string]any copy
-workflow.InputsFromContext(ctx)             // returns map[string]any copy
+req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
 ```
 
 ### Intra-activity progress reporting
@@ -301,56 +333,58 @@ workflow.ReportProgress(ctx, workflow.ProgressDetail{
 ## Execution
 
 ```go
-execution, _ := workflow.NewExecution(workflow.ExecutionOptions{
-    Workflow:           w,
-    Inputs:             map[string]any{"url": "https://example.com"},
-    Activities:         []workflow.Activity{...},
-    Logger:             slog.New(slog.NewTextHandler(os.Stdout, nil)),
-    Checkpointer:       checkpointer,         // optional, defaults to NullCheckpointer
-    ActivityLogger:     activityLogger,        // optional, defaults to NullActivityLogger
-    ExecutionCallbacks: callbacks,             // optional, defaults to BaseExecutionCallbacks
-    StepProgressStore:  store,                 // optional, tracks step state transitions
-    ExecutionID:        "custom-id",           // optional, auto-generated if empty
-    // ScriptCompiler defaults to DefaultScriptCompiler() (expr-backed).
-})
+reg := workflow.NewActivityRegistry()
+reg.MustRegister(activity1, activity2, ...)
 
-// Run to completion (returns error)
-err := execution.Run(ctx)
-
-// Resume from a previous execution's checkpoint
-err := execution.Resume(ctx, "prior-execution-id")
-
-// Resume or fall back to fresh run if no checkpoint exists
-err := execution.RunOrResume(ctx, "prior-execution-id")
-
-// Structured result variants (recommended)
-result, err := execution.Execute(ctx)
-result, err := execution.ExecuteOrResume(ctx, "prior-execution-id")
-
-// Inspect results
-execution.ID()         // string
-execution.Status()     // ExecutionStatus
-execution.GetOutputs() // map[string]any
+exec, err := workflow.NewExecution(wf, reg,
+    workflow.WithInputs(map[string]any{"url": "https://example.com"}),
+    workflow.WithLogger(slog.New(slog.NewTextHandler(os.Stdout, nil))),
+    workflow.WithCheckpointer(checkpointer),       // optional, defaults to NullCheckpointer
+    workflow.WithActivityLogger(activityLogger),    // optional
+    workflow.WithStepProgressStore(store),          // optional
+    workflow.WithExecutionID("custom-id"),          // optional, auto-generated if empty
+    workflow.WithScriptCompiler(myCompiler),        // optional, defaults to expr-backed
+)
 ```
 
-### Run vs Execute
+`NewExecution` is the binding step: it validates that every activity
+referenced by a step is registered, every template parses, and every
+edge condition compiles. Failures are returned as a
+`*ValidationError` with one `ValidationProblem` per issue.
 
-`Run`/`Resume`/`RunOrResume` return `error`. `Execute`/`ExecuteOrResume`
-return `(*ExecutionResult, error)` with richer semantics:
+Run an execution:
+
+```go
+// Single entry point — returns a structured result.
+result, err := exec.Execute(ctx)
+
+// Resume from a prior execution's checkpoint, falling back to a
+// fresh run if no checkpoint exists.
+result, err := exec.Execute(ctx, workflow.ResumeFrom("prior-execution-id"))
+
+// Inspect
+exec.ID()      // string
+exec.Status()  // ExecutionStatus
+```
+
+### Result semantics
+
 - `error` non-nil = infrastructure failure (couldn't start). Result is nil.
 - `error` nil = execution ran. Inspect `result.Status` for the outcome.
 - Workflow failures are in `result.Error`, not the `error` return.
 
 ```go
-result, err := exec.ExecuteOrResume(ctx, priorID)
+result, err := exec.Execute(ctx, workflow.ResumeFrom(priorID))
 if err != nil {
     return err // infrastructure failure
 }
-if result.Completed() {
+switch {
+case result.Completed():
     fmt.Println(result.Outputs)
-}
-if result.Failed() {
+case result.Failed():
     fmt.Println(result.Error.Cause)
+case result.NeedsResume():
+    // Schedule a resume — see Suspension model section.
 }
 ```
 
@@ -364,6 +398,7 @@ type ExecutionResult struct {
     Error        *WorkflowError     // nil on success
     Timing       ExecutionTiming    // StartedAt, FinishedAt, Duration
     FollowUps    []FollowUpSpec     // from completion hooks
+    Suspension   *SuspensionInfo    // populated when NeedsResume()
 }
 
 result.Completed()  // true if status is completed
@@ -373,9 +408,27 @@ result.Paused()     // true if parked by PauseBranch or a Pause step
 result.NeedsResume() // Suspended() || Paused()
 ```
 
-When an execution ends dormant (`Suspended` or `Paused`), `result.Suspension`
-is populated with a `*SuspensionInfo` describing what external trigger is
-required to move it forward — see the **Signals, waits, and pausing** section.
+Output accessors (nil-safe on the receiver):
+
+```go
+val, ok := result.Output("key")          // raw any
+s,   ok := result.OutputString("key")
+n,   ok := result.OutputInt("key")        // accepts int/int32/int64/float32/float64
+b,   ok := result.OutputBool("key")
+v,   ok := workflow.OutputAs[MyType](result, "key") // generic
+```
+
+Suspension accessors:
+
+```go
+reason := result.WaitReason()             // "" if not suspended
+topics := result.Topics()                 // nil if not suspended on a signal
+when, ok := result.NextWakeAt()           // false if no wall-clock deadline
+```
+
+When an execution ends dormant (`Suspended` or `Paused`),
+`result.Suspension` describes what external trigger is required to
+move it forward — see the **Signals, waits, and pausing** section.
 
 Execution statuses: `ExecutionStatusPending`, `ExecutionStatusRunning`,
 `ExecutionStatusWaiting` (intra-run join block), `ExecutionStatusSuspended`
@@ -384,10 +437,13 @@ Execution statuses: `ExecutionStatusPending`, `ExecutionStatusRunning`,
 
 ## Workflow validation
 
-Validate workflow structure at registration time:
+Structural validation runs inside `workflow.New`. Bad inputs come
+back as a `*ValidationError` with one `ValidationProblem` per
+distinct issue:
 
 ```go
-if err := wf.Validate(); err != nil {
+wf, err := workflow.New(workflow.Options{Steps: steps})
+if err != nil {
     var ve *workflow.ValidationError
     if errors.As(err, &ve) {
         for _, p := range ve.Problems {
@@ -397,9 +453,13 @@ if err := wf.Validate(); err != nil {
 }
 ```
 
-`Validate()` checks: unreachable steps (BFS from start), invalid join path
-references, and dangling catch handler step references. It does not check
-activity names (those surface at runtime).
+`workflow.New` checks: empty/duplicate step names, unreachable steps
+(BFS from start), edge/catch/join targets that don't exist, mixed
+step kinds, modifier fields on the wrong kind, retry/sleep/wait
+config validity, reserved/duplicate branch names, and template/
+expression syntax. Activity registration and binding-layer
+validation (parameters bound against the registry, conditions bound
+against the script compiler) run during `NewExecution`.
 
 ## Checkpointing
 
@@ -460,9 +520,10 @@ type StepProgressStore interface {
 }
 ```
 
-Set `StepProgressStore` on `ExecutionOptions`. The library calls
-`UpdateStepProgress` asynchronously on each step state transition (pending,
-running, completed, failed). Errors are logged but do not fail the workflow.
+Set the store via `workflow.WithStepProgressStore(store)` on
+`NewExecution`. The library calls `UpdateStepProgress` asynchronously
+on each step state transition (pending, running, completed, failed).
+Errors are logged but do not fail the workflow.
 
 ```go
 type StepProgress struct {
@@ -485,7 +546,7 @@ type ProgressDetail struct {
 
 ## Execution callbacks
 
-Observe workflow, path, and activity lifecycle events:
+Observe workflow, branch, and activity lifecycle events:
 
 ```go
 type ExecutionCallbacks interface {
@@ -498,47 +559,54 @@ type ExecutionCallbacks interface {
 }
 ```
 
-Embed `BaseExecutionCallbacks` to get default no-ops and override only what
-you need. Use `NewCallbackChain(callbacks...)` to chain multiple
-implementations.
+Embed `BaseExecutionCallbacks` to get default no-ops and override
+only what you need. Pass via `workflow.WithCallbacks(...)` on
+`NewExecution`. Chain multiple implementations with
+`NewCallbackChain(callbacks...)`.
 
 ## Runner
 
-The Runner is the recommended entry point for production consumers. It
-composes heartbeating, timeout management, crash recovery (resume-or-run),
-structured results, and completion hooks into a single `Run` call.
+The Runner is the recommended entry point for production consumers.
+It composes heartbeating, timeout management, crash recovery
+(resume-or-run), structured results, and completion hooks into a
+single `Run` call.
 
 ```go
-runner := workflow.NewRunner(workflow.RunnerConfig{
-    Logger:         slog.Default(),
-    DefaultTimeout: 30 * time.Minute,
-})
+runner := workflow.NewRunner(
+    workflow.WithRunnerLogger(slog.Default()),
+    workflow.WithDefaultTimeout(30 * time.Minute),
+)
 
-result, err := runner.Run(ctx, exec, workflow.RunOptions{
-    PriorExecutionID: priorID,  // empty = fresh run
-
-    Heartbeat: &workflow.HeartbeatConfig{
+result, err := runner.Run(ctx, exec,
+    workflow.WithResumeFrom(priorID),     // empty/omitted = fresh run
+    workflow.WithHeartbeat(&workflow.HeartbeatConfig{
         Interval: 10 * time.Second,
         Func: func(ctx context.Context) error {
             return leaseManager.Renew(ctx, jobID, workerID)
         },
-    },
-
-    CompletionHook: func(ctx context.Context, r *workflow.ExecutionResult) ([]workflow.FollowUpSpec, error) {
+    }),
+    workflow.WithCompletionHook(func(ctx context.Context, r *workflow.ExecutionResult) ([]workflow.FollowUpSpec, error) {
         return []workflow.FollowUpSpec{{
             WorkflowName: "report",
             Inputs:       r.Outputs,
         }}, nil
-    },
-})
+    }),
+)
 ```
 
-The caller creates the `Execution` with `ExecutionOptions` as usual. The
-Runner adds lifecycle management on top:
-- **PriorExecutionID**: triggers `ExecuteOrResume` (falls back to fresh run if no checkpoint)
-- **Heartbeat**: periodic liveness check; cancels execution context on failure
-- **Timeout**: per-execution or default from config; negative disables default
-- **CompletionHook**: called after successful execution to produce follow-up specs
+The caller creates the `Execution` with `NewExecution` as usual.
+The Runner adds lifecycle management on top:
+
+- **WithResumeFrom**: resume-or-run; falls back to a fresh run if no
+  checkpoint exists for the prior ID.
+- **WithHeartbeat**: periodic liveness check; cancels the execution
+  context on heartbeat failure.
+- **WithDefaultTimeout** / **WithRunTimeout**: default timeout for
+  every Run, optionally overridden per call. Negative disables.
+- **WithCompletionHook**: called after a successful execution to
+  produce follow-up workflow specs. Returning an error from the hook
+  does not change the execution result; the partial follow-up list
+  is still attached to `result.FollowUps`.
 
 ### Completion hooks and follow-ups
 
@@ -582,16 +650,13 @@ type SignalStore interface {
   `Wait`/`WaitSignal` always call `Receive` before blocking. The store is
   the rendezvous, not goroutines — a signal delivered before the wait
   registers is not lost.
-- Pass via `ExecutionOptions.SignalStore`.
+- Pass via `workflow.WithSignalStore(...)` on `NewExecution`.
 
 ```go
 signals := workflow.NewMemorySignalStore()
-exec, _ := workflow.NewExecution(workflow.ExecutionOptions{
-    Workflow:    wf,
-    Activities:  activities,
-    SignalStore: signals,
-    // ...
-})
+exec, _ := workflow.NewExecution(wf, reg,
+    workflow.WithSignalStore(signals),
+)
 ```
 
 ### Imperative Wait (inside activities)
@@ -600,7 +665,7 @@ exec, _ := workflow.NewExecution(workflow.ExecutionOptions{
 import "github.com/deepnoodle-ai/workflow"
 
 func Execute(ctx workflow.Context, params map[string]any) (any, error) {
-    reply, err := workflow.Wait(ctx, "callback-"+uuid, 7*24*time.Hour)
+    reply, err := ctx.Wait("callback-"+uuid, 7*24*time.Hour)
     if err != nil {
         return nil, err  // ctx cancellation or ErrWaitTimeout
     }
@@ -608,35 +673,34 @@ func Execute(ctx workflow.Context, params map[string]any) (any, error) {
 }
 ```
 
-`workflow.Wait` is **durable**: if no signal is present, the activity
-unwinds via a sentinel error, the path hard-suspends, the checkpoint is
-saved, and the execution returns with `Status = Suspended`. On resume
-(after the signal arrives) the entire activity **re-executes from its
-entry point** — the second `Wait` call finds the delivered signal and
-returns immediately.
+`ctx.Wait` is **durable**: if no signal is present, the activity
+unwinds via a sentinel error, the branch hard-suspends, the
+checkpoint is saved, and the execution returns with
+`Status = Suspended`. On resume (after the signal arrives) the
+entire activity **re-executes from its entry point** — the second
+`Wait` call finds the delivered signal and returns immediately. See
+`docs/suspension.md` for the full replay-safety contract.
 
-**Replay-safety contract**: any code an activity runs before a `Wait` call
-may execute more than once. Wrap expensive or non-idempotent work in
-`ActivityHistory.RecordOrReplay` (below), or use natural idempotency keys
-(HTTP PUT, Stripe idempotency keys, Postgres upserts). See §9 of
-`planning/prds/002-signals-waits-pausing.md` for the authoritative contract.
+**Replay-safety contract**: any code an activity runs before a
+`Wait` call may execute more than once. Wrap expensive or
+non-idempotent work in `Context.History` /
+`workflow.RecordOrReplay`, or use natural idempotency keys (HTTP
+PUT, Stripe idempotency keys, Postgres upserts).
 
-**Multiple waits in one activity.** If an activity calls `Wait` more than
-once (e.g. an agent loop that interleaves tool calls and callbacks), each
-`Wait` MUST be wrapped in `ActivityHistory.RecordOrReplay`. Without
-wrapping, the second-wait suspension causes the activity to replay from
-the top and re-call the first `Wait` against an empty store — the first
-signal has already been consumed. The result is undefined: the first
-`Wait` may re-suspend, or worse, consume a signal intended for a
-different wait. Wrapping caches each `Wait` result on success so replays
-short-circuit through the cache:
+**Multiple waits in one activity.** If an activity calls `Wait`
+more than once (e.g., an agent loop that interleaves tool calls and
+callbacks), each `Wait` MUST be wrapped in `RecordOrReplay`. Without
+wrapping, the second-wait suspension causes the activity to replay
+from the top and re-call the first `Wait` against an empty store —
+the first signal has already been consumed. Wrapping caches each
+`Wait` result on success so replays short-circuit through the cache:
 
 ```go
-v1, err := history.RecordOrReplay("wait1", func() (any, error) {
-    return workflow.Wait(ctx, topic1, time.Hour)
+v1, err := workflow.RecordOrReplay(ctx.History(), "wait1", func() (any, error) {
+    return ctx.Wait(topic1, time.Hour)
 })
-v2, err := history.RecordOrReplay("wait2", func() (any, error) {
-    return workflow.Wait(ctx, topic2, time.Hour)
+v2, err := workflow.RecordOrReplay(ctx.History(), "wait2", func() (any, error) {
+    return ctx.Wait(topic2, time.Hour)
 })
 ```
 
@@ -795,32 +859,32 @@ The typical consumer pattern on a Suspended result:
    to those topics in your signal delivery system.
 2. If `Suspension.WakeAt` is non-zero, enqueue a delayed resume job that
    runs at or after `WakeAt`.
-3. When the trigger fires, call `runner.Run(ctx, exec, RunOptions{
-   PriorExecutionID: execID})` on a fresh `Execution` with the same
-   `ExecutionID` to resume.
+3. When the trigger fires, call
+   `runner.Run(ctx, exec, workflow.WithResumeFrom(execID))` on a fresh
+   `Execution` built from the same workflow + registry to resume.
 
 ### Known-good patterns
 
-- **AI agent callback**: declarative `WaitSignal` step when the callback
-  ID is known at step-definition time; imperative `workflow.Wait` + a
-  UUID generated inside the activity when the ID is dynamic. Wrap LLM
-  calls in `ActivityHistory.RecordOrReplay` to avoid re-billing on resume.
+- **AI agent callback**: declarative `WaitSignal` step when the
+  callback ID is known at step-definition time; imperative `ctx.Wait`
+  + a UUID generated inside the activity when the ID is dynamic.
+  Wrap LLM calls in `RecordOrReplay` to avoid re-billing on resume.
 - **Human-in-the-loop approval**: declarative `Pause` step. Operator
-  unpauses via `UnpauseBranchInCheckpoint` from the UI, then re-runs the
-  workflow from the scheduled-jobs system.
-- **Long retry delay**: declarative `Sleep` step. Consumer schedules a
-  delayed job at `Suspension.WakeAt`.
-- **Distributed Wait**: plug a Postgres-backed `SignalStore` into
-  `ExecutionOptions.SignalStore`; the rest of the machinery works
-  unchanged.
+  unpauses via `UnpauseBranchInCheckpoint` from the UI, then re-runs
+  the workflow from the scheduled-jobs system.
+- **Long retry delay**: declarative `Sleep` step. Consumer schedules
+  a delayed job at `Suspension.WakeAt`.
+- **Distributed Wait**: plug a Postgres-backed `SignalStore` via
+  `WithSignalStore`; the rest of the machinery works unchanged.
 
 ## String templating and the expression engine
 
 Step parameters and edge conditions are evaluated by
-`github.com/deepnoodle-ai/expr`, a small Go-subset expression evaluator
-that ships as the root module's single external dependency. It is wired
-in automatically via `DefaultScriptCompiler()`; consumers do not need to
-set `ExecutionOptions.ScriptCompiler` unless they want a different
+`github.com/deepnoodle-ai/expr`, a small Go-subset expression
+evaluator that ships as the root module's single external
+dependency. It is wired in automatically via
+`DefaultScriptCompiler()`; consumers do not need to set
+`WithScriptCompiler` on `NewExecution` unless they want a different
 engine.
 
 Parameter values use `${expr}` templates. When the template covers the
@@ -859,7 +923,7 @@ step's `Store` field:
     Name:     "Increment",
     Activity: "increment",            // typed activity: (int) -> int
     Parameters: map[string]any{"value": "${state.counter}"},
-    Store: "state.counter",
+    Store: "counter",
 }
 ```
 
@@ -874,7 +938,8 @@ type Compiler interface {
 }
 ```
 
-and pass it via `ExecutionOptions.ScriptCompiler`. `script.IsTruthyValue`
+and pass it via `workflow.WithScriptCompiler(...)` on `NewExecution`.
+`script.IsTruthyValue`
 and `script.EachValue` are exported helpers that make writing a
 `script.Value` implementation straightforward — see
 `script_compiler.go` in the root module for the expr adapter this
@@ -901,7 +966,7 @@ Activities ship in three sub-packages, organised by guarantee level:
 | `json`            | `activities`            | JSON parse/stringify         | `operation`, `data`                     |
 | `random`          | `activities`            | Generate random values       | `min`, `max`                            |
 | `fail`            | `activities`            | Fail with error              | `error`, `type`                         |
-| `workflow.child`  | `activities`            | Execute child workflow       | `workflow_name`, `sync`, `inputs`       |
+| `workflow.child`  | `activities`            | Execute child workflow       | `workflow_name`, `inputs`, `timeout`    |
 | `http`            | `activities/httpx`      | Make HTTP request            | `url`, `method`, `headers`, `body`      |
 | `shell`           | `activities/contrib`    | Execute shell command        | `command`                               |
 | `file`            | `activities/contrib`    | File read/write              | `operation`, `path`, `content`          |
@@ -1016,24 +1081,28 @@ above) to compute the new value and write it back.
 
 ## State management
 
-Each execution path has its own `BranchLocalState` containing readonly inputs
-and mutable variables. When paths branch, child paths receive a complete copy
-of the parent's state. After branching, paths evolve independently with no
-synchronization. This eliminates race conditions and makes checkpointing
+Each branch has its own `BranchLocalState` containing readonly inputs
+and mutable variables. When edges fan out into multiple branches,
+child branches receive a deep copy of the parent's state. After
+branching, branches evolve independently with no synchronization.
+This eliminates race conditions and makes checkpointing
 straightforward.
 
 Activities access state through `workflow.Context`:
+
 ```go
 func(ctx workflow.Context, params map[string]any) (any, error) {
-    value, _ := ctx.GetVariable("counter")
-    ctx.SetVariable("counter", value.(int) + 1)
-    input, _ := ctx.GetInput("max_count")
+    value, _ := ctx.Get("counter")
+    ctx.Set("counter", value.(int) + 1)
+    input := ctx.Inputs()["max_count"]
     return value, nil
 }
 ```
 
-The `Store` field on a step automatically saves the activity's return value
-into the specified state variable. Use `"state.key"` syntax.
+The `Store` field on a step automatically saves the activity's
+return value into the named branch variable. Store fields must be
+*bare* variable names — `"counter"`, not `"state.counter"`. The
+`state.` prefix is reserved for templates and edge conditions.
 
 ## Example: Retry with catch fallback
 
@@ -1088,61 +1157,58 @@ w, _ := workflow.New(workflow.Options{
     },
 })
 
-execution, _ := workflow.NewExecution(workflow.ExecutionOptions{
-    Workflow: w,
-    Activities: []workflow.Activity{
-        workflow.ActivityFunc("do_work", func(ctx workflow.Context, params map[string]any) (any, error) {
-            // Return a WorkflowError with a custom type for fine-grained matching
-            return nil, workflow.NewWorkflowError("service-unavailable", "API is down")
-        }),
-        activities.NewPrintActivity(),
-    },
-})
+reg := workflow.NewActivityRegistry()
+reg.MustRegister(
+    workflow.ActivityFunc("do_work", func(ctx workflow.Context, params map[string]any) (any, error) {
+        // Return a WorkflowError with a custom type for fine-grained matching
+        return nil, workflow.NewWorkflowError("service-unavailable", "API is down")
+    }),
+    activities.NewPrintActivity(),
+)
 
-execution.Run(context.Background())
-fmt.Println(execution.GetOutputs()) // {"final_result": nil}
+exec, _ := workflow.NewExecution(w, reg)
+result, _ := exec.Execute(context.Background())
+fmt.Println(result.Outputs) // {"final_result": nil}
 ```
 
 ## Example: Production worker with Runner
 
 ```go
 func processWorkflow(ctx context.Context, job *Job) error {
-    exec, err := workflow.NewExecution(workflow.ExecutionOptions{
-        Workflow:          job.Workflow,
-        Activities:        allActivities,
-        Inputs:            job.Inputs,
-        ExecutionID:       job.ExecutionID,
-        Checkpointer:      workflow.WithFencing(pgCheckpointer, leaseCheck(job.ID)),
-        StepProgressStore: &DBStepProgressStore{db: db, jobID: job.ID},
-        Logger:            slog.Default(),
-    })
+    exec, err := workflow.NewExecution(job.Workflow, allActivities,
+        workflow.WithInputs(job.Inputs),
+        workflow.WithExecutionID(job.ExecutionID),
+        workflow.WithCheckpointer(workflow.WithFencing(pgCheckpointer, leaseCheck(job.ID))),
+        workflow.WithStepProgressStore(&DBStepProgressStore{db: db, jobID: job.ID}),
+        workflow.WithLogger(slog.Default()),
+    )
     if err != nil {
         return fmt.Errorf("creating execution: %w", err)
     }
 
-    runner := workflow.NewRunner(workflow.RunnerConfig{
-        Logger:         slog.Default(),
-        DefaultTimeout: 30 * time.Minute,
-    })
+    runner := workflow.NewRunner(
+        workflow.WithRunnerLogger(slog.Default()),
+        workflow.WithDefaultTimeout(30 * time.Minute),
+    )
 
-    result, err := runner.Run(ctx, exec, workflow.RunOptions{
-        PriorExecutionID: job.PriorExecutionID,
-        Heartbeat: &workflow.HeartbeatConfig{
+    result, err := runner.Run(ctx, exec,
+        workflow.WithResumeFrom(job.PriorExecutionID),
+        workflow.WithHeartbeat(&workflow.HeartbeatConfig{
             Interval: 10 * time.Second,
             Func: func(ctx context.Context) error {
                 return leaseManager.Renew(ctx, job.ID, workerID)
             },
-        },
-        CompletionHook: func(ctx context.Context, r *workflow.ExecutionResult) ([]workflow.FollowUpSpec, error) {
-            if name := r.Outputs["next_workflow"]; name != nil {
+        }),
+        workflow.WithCompletionHook(func(ctx context.Context, r *workflow.ExecutionResult) ([]workflow.FollowUpSpec, error) {
+            if name, ok := r.OutputString("next_workflow"); ok {
                 return []workflow.FollowUpSpec{{
-                    WorkflowName: name.(string),
+                    WorkflowName: name,
                     Inputs:       r.Outputs,
                 }}, nil
             }
             return nil, nil
-        },
-    })
+        }),
+    )
     if err != nil {
         return err
     }
@@ -1193,35 +1259,34 @@ metrics := &MetricsCallbacks{}
 logging := &LoggingCallbacks{logger: slog.Default()}
 callbacks := workflow.NewCallbackChain(metrics, logging)
 
-execution, _ := workflow.NewExecution(workflow.ExecutionOptions{
-    Workflow:           w,
-    Activities:         myActivities,
-    ExecutionCallbacks: callbacks,
-})
+reg := workflow.NewActivityRegistry()
+reg.MustRegister(myActivities...)
 
-execution.Run(ctx)
+exec, _ := workflow.NewExecution(w, reg, workflow.WithCallbacks(callbacks))
+exec.Execute(ctx)
 fmt.Println(metrics.Executions, metrics.ActivityTime)
 ```
 
 Callback event types and their key fields:
 
-- `WorkflowExecutionEvent` - ExecutionID, WorkflowName, Status, StartTime, EndTime, Duration, Inputs, Outputs, PathCount, Error
-- `BranchExecutionEvent` - ExecutionID, WorkflowName, BranchID, Status, StartTime, EndTime, Duration, CurrentStep, StepOutputs, Error
-- `ActivityExecutionEvent` - ExecutionID, WorkflowName, BranchID, StepName, ActivityName, Parameters, Result, StartTime, EndTime, Duration, Error
+- `WorkflowExecutionEvent` — ExecutionID, WorkflowName, Status, StartTime, EndTime, Duration, Inputs, Outputs, BranchCount, Error
+- `BranchExecutionEvent` — ExecutionID, WorkflowName, BranchID, Status, StartTime, EndTime, Duration, CurrentStep, StepOutputs, Error
+- `ActivityExecutionEvent` — ExecutionID, WorkflowName, BranchID, StepName, ActivityName, Parameters, Result, StartTime, EndTime, Duration, Error
 
 ## Key types
 
-- `Workflow` - created via `New(Options)`, defines the step graph
-- `Step` - node in the graph: activity, parameters, edges, retry, catch
-- `Edge` - connection between steps with optional condition and path name
-- `Execution` - runs a workflow; created via `NewExecution(ExecutionOptions)`
-- `ExecutionResult` - structured outcome from `Execute`/`ExecuteOrResume`
-- `ExecutionStatus` - pending, running, waiting, completed, failed
-- `Activity` - interface: Name, Execute
-- `TypedActivity[T, R]` - generic activity with typed params and result
-- `Context` - extends context.Context with state access for activities
-- `VariableContainer` - interface: SetVariable, GetVariable, DeleteVariable, ListVariables
-- `BranchLocalState` - per-path state container (inputs + variables)
+- `Workflow` — created via `New(Options)`, defines the step graph
+- `Step` — node in the graph; exactly one kind: Activity / Join / WaitSignal / Sleep / Pause
+- `Edge` — connection between steps with optional condition and BranchName
+- `ActivityRegistry` — name → activity lookup; built once via `NewActivityRegistry`
+- `Execution` — runs a workflow; created via `NewExecution(wf, registry, ...opts)`
+- `Runner` — production wrapper around `Execution.Execute` (heartbeat, timeout, hooks, resume)
+- `ExecutionResult` — structured outcome from `Execute`
+- `ExecutionStatus` — pending, running, suspended, paused, completed, failed
+- `Activity` — interface: Name, Execute
+- `TypedActivity[T, R]` — generic activity with typed params and result
+- `Context` — embeds context.Context; adds state access, Wait, History, ReportProgress
+- `BranchLocalState` — per-branch state container (inputs + variables)
 - `Checkpoint` - serializable snapshot of execution state
 - `Checkpointer` - interface: SaveCheckpoint, LoadCheckpoint, DeleteCheckpoint
 - `ActivityLogger` - interface: LogActivity, GetActivityHistory
@@ -1229,31 +1294,35 @@ Callback event types and their key fields:
 - `WorkflowError` - structured error with Type, Cause, Details
 - `RetryConfig` - retry policy: ErrorEquals, MaxRetries, BaseDelay, BackoffRate, JitterStrategy
 - `CatchConfig` - error handler: ErrorEquals, Next step, Store variable
-- `JoinConfig` - path convergence: Paths, Count, BranchMappings
-- `Patch` - represents a state variable change (Variable, Value, Delete)
-- `Runner` - production entry point with heartbeat, timeout, hooks
-- `RunnerConfig` - Logger, DefaultTimeout
-- `RunOptions` - PriorExecutionID, Heartbeat, CompletionHook, Timeout
-- `HeartbeatConfig` - Interval, Func
-- `CompletionHook` - post-success callback returning FollowUpSpecs
-- `FollowUpSpec` - descriptor for follow-up workflows (WorkflowName, Inputs, Metadata)
-- `StepProgressStore` - interface: UpdateStepProgress
-- `StepProgress` - step state snapshot (StepName, BranchID, Status, Attempt, Detail, timing)
-- `ProgressDetail` - intra-activity progress (Message, Data)
-- `ValidationError` - contains []ValidationProblem from Validate()
-- `ErrNoCheckpoint` - sentinel: no checkpoint found
-- `ErrFenceViolation` - sentinel: worker lost lease (non-retryable)
-- `FenceFunc` - lease validation function for WithFencing
+- `JoinConfig` — branch convergence: Branches, Count, BranchMappings
+- `Patch` — represents a state variable change (Variable, Value, Delete)
+- `Runner` — production entry point with heartbeat, timeout, hooks
+- `RunnerOption` — `WithRunnerLogger`, `WithDefaultTimeout`
+- `RunOption` — `WithResumeFrom`, `WithHeartbeat`, `WithCompletionHook`, `WithRunTimeout`
+- `HeartbeatConfig` — Interval, Func
+- `CompletionHook` — post-success callback returning FollowUpSpecs
+- `FollowUpSpec` — descriptor for follow-up workflows (WorkflowName, Inputs, Metadata)
+- `StepProgressStore` — interface: UpdateStepProgress
+- `StepProgress` — step state snapshot (StepName, BranchID, Status, Attempt, Detail, timing)
+- `ProgressDetail` — intra-activity progress (Message, Data)
+- `ValidationError` — contains []ValidationProblem from `workflow.New` / `NewExecution`
+- `ErrNoCheckpoint` — sentinel: no checkpoint found
+- `ErrFenceViolation` — sentinel: worker lost lease (non-retryable)
+- `ErrWaitTimeout` — sentinel: durable wait timeout
+- `FenceFunc` — lease validation function for WithFencing
 
 ## Docs and examples
 
-- [README](README.md)
+- [README](README.md) — quick example with Runner
+- [MIGRATION](MIGRATION.md) — pre-v1 → v1 breaking changes
+- [docs/suspension.md](docs/suspension.md) — suspend/resume/replay-safety contract
+- [docs/production_checklist.md](docs/production_checklist.md) — production punch list
 - [Overview](documentation/overview.md)
 - [State Management](documentation/state-management.md)
 - [Child Workflows](documentation/child-workflows.md)
 - [Error Handling](documentation/error-handling.md)
 - [Edge Matching Strategies](documentation/edge-matching-strategies.md)
-- [examples/](examples/) - runnable examples for each feature
+- [examples/](examples/) — runnable examples for each feature
 
 ## Related projects
 

--- a/step.go
+++ b/step.go
@@ -109,7 +109,48 @@ type JoinConfig struct {
 	BranchMappings map[string]string `json:"branch_mappings,omitempty"`
 }
 
-// Step represents a single step in a workflow.
+// Step represents a single node in a workflow's step graph.
+//
+// # Step kinds
+//
+// A step has exactly one kind, selected by which of these mutually
+// exclusive fields is set:
+//
+//   - Activity — invokes a registered activity by name. The default
+//     kind; the only kind that produces a value via Store.
+//   - Join — waits for one or more named branches to converge,
+//     then merges their state per JoinConfig.BranchMappings.
+//   - WaitSignal — parks the branch until an external signal is
+//     delivered to a topic.
+//   - Sleep — durably suspends the branch for a wall-clock duration.
+//     Survives process restarts.
+//   - Pause — declarative counterpart to PauseBranch; parks the
+//     branch until an operator unpauses it.
+//
+// workflow.New rejects any step that sets more than one kind field
+// with ErrInvalidStepKind, and any step that sets none with the
+// implicit "activity" default — Activity may be empty only if a
+// Sleep, Pause, Join, or WaitSignal is set.
+//
+// # Modifier fields
+//
+//   - Store — name of the variable to write the step result into.
+//     Activity-kind only.
+//   - Parameters — typed input passed to the activity (Activity-kind
+//     only). Values may use ${...} templates.
+//   - Each — fan-out loop over a list. The step is executed once
+//     per item in a fresh sub-branch.
+//   - Next — outgoing edges, evaluated against EdgeMatchingStrategy.
+//   - EdgeMatchingStrategy — "all" (default; follow every matching
+//     edge, branching the path) or "first" (follow only the first
+//     match, single branch continues).
+//   - Retry — per-error-class retry policy with backoff. Activity-kind
+//     only; rejected on Sleep/Pause/Join/WaitSignal at workflow.New.
+//   - Catch — per-error-class fallback routing. Activity-kind only;
+//     same restriction as Retry.
+//
+// Mixing a modifier with an incompatible kind is rejected at
+// validation time with ErrInvalidModifier.
 type Step struct {
 	Name                 string               `json:"name"`
 	Description          string               `json:"description,omitempty"`


### PR DESCRIPTION
## Summary

The library should be recommendable to someone reading the README, the MIGRATION doc, and the suspension model doc cold. This PR updates the docs to reflect the v1 surface and contracts.

### Long-form docs

- **`README.md`** — quick example uses `Runner` and the v1 functional-options constructors. Adds a "Going to production" section linking to the new docs.
- **`MIGRATION.md`** (new) — every breaking change between pre-v1 and v1 with before/after snippets, organised by PR.
- **`docs/suspension.md`** (new) — the consolidated suspension model: the three reasons table, lifecycle diagram, replay-safety contract, `RecordOrReplay` shape, scheduling-resume recipe, dominant-reason precedence rule.
- **`docs/production_checklist.md`** (new) — punch list for taking the library to production: storage, execution, activity authoring, suspension/resume, observability, worker hygiene.
- **`llms.txt`** — reflects v1 API throughout. Replaces every stale `Path`/`path` reference with `Branch`, every `ExecutionOptions` struct example with the functional-options constructor, every `execution.Run`/`Resume`/`RunOrResume` with `exec.Execute`, every `GetVariable`/`SetVariable` with `Get`/`Set`, every `RunnerConfig`/`RunOptions` with `NewRunner` / Run options, and adds the new `ExecutionResult` helpers (`OutputString`/`OutputInt`/`OutputBool`/`OutputAs`/`WaitReason`/`Topics`/`NextWakeAt`) to the Execution section.

### Godoc

- **`checkpoint.go`** — `Checkpoint` godoc gets a "Load-bearing fields" section that explicitly lists `BranchState.Variables` / `Wait` / `PauseRequested` / `ActivityHistory` as round-trip-required.
- **`step.go`** — `Step` godoc documents the now-validated "exactly one kind" rule and the modifier-field restrictions.
- **`context.go`** — `Context.Wait` godoc spells out the behavior, the replay-safety contract, the deadline rules, and the custom-Context-implementer contract. Includes the canonical `RecordOrReplay` shape.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test -count=1 ./...` passes
- [x] All linked docs (`docs/suspension.md`, `docs/production_checklist.md`, `MIGRATION.md`) exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)