### PR TITLE
fix: address CodeRabbit review feedback from PR #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ func main() {
 				},
 			},
 		},
+		Outputs: []*workflow.Output{
+			{Name: "result", Variable: "result"},
+		},
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/activity_registry.go
+++ b/activity_registry.go
@@ -26,6 +26,12 @@ func NewActivityRegistry() *ActivityRegistry {
 // Register adds an activity to the registry. Returns ErrDuplicateActivity
 // if an activity with the same name is already registered.
 func (r *ActivityRegistry) Register(a Activity) error {
+	if r == nil {
+		return fmt.Errorf("workflow: nil activity registry")
+	}
+	if r.activities == nil {
+		r.activities = make(map[string]Activity)
+	}
 	if a == nil {
 		return fmt.Errorf("workflow: nil activity")
 	}

--- a/branch_join_test.go
+++ b/branch_join_test.go
@@ -2,6 +2,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -166,10 +167,18 @@ func TestBranchJoining(t *testing.T) {
 			pathYMap := pathY.(map[string]any)
 
 			// Verify full branch state was captured
-			require.Equal(t, "x_processed", pathXMap["x_meta"])
-			require.Equal(t, "y_processed", pathYMap["y_meta"])
-			require.Equal(t, 20, pathXMap["x_data"]) // 5 * 4
-			require.Equal(t, 30, pathYMap["y_data"]) // 5 * 6
+			if pathXMap["x_meta"] != "x_processed" {
+				return nil, fmt.Errorf("expected x_meta=x_processed, got %v", pathXMap["x_meta"])
+			}
+			if pathYMap["y_meta"] != "y_processed" {
+				return nil, fmt.Errorf("expected y_meta=y_processed, got %v", pathYMap["y_meta"])
+			}
+			if pathXMap["x_data"] != 20 {
+				return nil, fmt.Errorf("expected x_data=20, got %v", pathXMap["x_data"])
+			}
+			if pathYMap["y_data"] != 30 {
+				return nil, fmt.Errorf("expected y_data=30, got %v", pathYMap["y_data"])
+			}
 
 			return pathXMap["x_data"].(int) + pathYMap["y_data"].(int), nil
 		}))

--- a/branch_local_state.go
+++ b/branch_local_state.go
@@ -72,9 +72,3 @@ func (s *BranchLocalState) inputsSnapshot() map[string]any {
 	}
 	return out
 }
-
-// variablesMap returns the underlying map by reference. Internal-only
-// accessor used by the engine for state snapshot/restore under lock.
-func (s *BranchLocalState) variablesMap() map[string]any {
-	return s.variables
-}

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -11,10 +11,10 @@ import "time"
 //   - v1: Initial stable schema. Locked at v1 release.
 //
 // Consumers that persist checkpoints to their own storage MUST treat
-// SchemaVersion as a forward-compatibility signal: if a loaded
-// checkpoint has a SchemaVersion higher than the library version
-// understands, the load should fail rather than proceed with a
-// potentially wrong interpretation.
+// SchemaVersion as a compatibility signal: if a loaded checkpoint has
+// a SchemaVersion higher than the library version understands, or
+// lower than the minimum supported version (1), the load should fail
+// rather than proceed with a potentially wrong interpretation.
 const CheckpointSchemaVersion = 1
 
 // Checkpoint is the serialized snapshot of an execution. It is the

--- a/checkpoint_test.go
+++ b/checkpoint_test.go
@@ -49,7 +49,23 @@ func TestCheckpointNewerSchemaVersionIsRejected(t *testing.T) {
 
 	_, err = cp.LoadCheckpoint(context.Background(), "future-exec")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "newer than supported version")
+	require.Contains(t, err.Error(), "not supported")
+}
+
+func TestCheckpointOlderSchemaVersionIsRejected(t *testing.T) {
+	cp := workflowtest.NewMemoryCheckpointer()
+	err := cp.SaveCheckpoint(context.Background(), &workflow.Checkpoint{
+		SchemaVersion: 0,
+		ID:            "cp1",
+		ExecutionID:   "old-exec",
+		WorkflowName:  "test",
+		Status:        workflow.ExecutionStatusRunning,
+	})
+	require.NoError(t, err)
+
+	_, err = cp.LoadCheckpoint(context.Background(), "old-exec")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
 }
 
 func TestMemoryCheckpointer_AtomicUpdate(t *testing.T) {

--- a/checkpointer_file.go
+++ b/checkpointer_file.go
@@ -80,8 +80,8 @@ func (c *FileCheckpointer) LoadCheckpoint(ctx context.Context, executionID strin
 	if err := json.Unmarshal(data, &checkpoint); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal checkpoint: %w", err)
 	}
-	if checkpoint.SchemaVersion > CheckpointSchemaVersion {
-		return nil, fmt.Errorf("checkpoint schema version %d is newer than supported version %d",
+	if checkpoint.SchemaVersion < 1 || checkpoint.SchemaVersion > CheckpointSchemaVersion {
+		return nil, fmt.Errorf("checkpoint schema version %d is not supported (supported: 1..%d)",
 			checkpoint.SchemaVersion, CheckpointSchemaVersion)
 	}
 

--- a/child_workflow.go
+++ b/child_workflow.go
@@ -201,7 +201,16 @@ func (e *DefaultChildWorkflowExecutor) ExecuteSync(ctx context.Context, spec *Ch
 			cwr.Outputs[k] = v
 		}
 	}
-	return cwr, execErr
+	if execErr != nil {
+		return cwr, execErr
+	}
+	if result != nil && result.Status == ExecutionStatusFailed {
+		if result.Error != nil {
+			return cwr, result.Error
+		}
+		return cwr, fmt.Errorf("child workflow execution failed")
+	}
+	return cwr, nil
 }
 
 // newChildExecution builds an Execution for a child workflow using the

--- a/cmd/workflow/main.go
+++ b/cmd/workflow/main.go
@@ -132,11 +132,11 @@ func main() {
 	info("Starting execution (ID: %s)...", execution.ID())
 
 	startTime := time.Now()
-	_, err = execution.Execute(ctx)
+	result, err := execution.Execute(ctx)
 	duration := time.Since(startTime)
 
 	// Show execution results
-	showExecutionResults(execution, err, duration, config)
+	showExecutionResults(result, err, duration, config)
 }
 
 // loadWorkflow reads a JSON workflow definition from disk and constructs
@@ -208,7 +208,6 @@ Options:
 Supported Activities:
   print          - Print messages to console
   time           - Get current timestamp
-  wait           - Wait for a specified duration
   fail           - Intentionally fail with a message
   http           - Make HTTP requests
   file           - Read, write, and manage files
@@ -366,42 +365,47 @@ func prepareInputs(wf *workflow.Workflow, providedInputs map[string]interface{})
 	return inputs, nil
 }
 
-func showExecutionResults(execution *workflow.Execution, err error, duration time.Duration, config *Config) {
-	status := execution.Status()
-
+func showExecutionResults(result *workflow.ExecutionResult, err error, duration time.Duration, config *Config) {
 	// Show execution summary
 	info("Execution completed in %v", duration)
-	info("Status: %s", status)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		if status != workflow.ExecutionStatusCompleted {
-			os.Exit(1)
-		}
-	} else {
-		info("Execution successful!")
+		os.Exit(1)
+	}
+	if result == nil {
+		fmt.Fprintf(os.Stderr, "Error: no execution result\n")
+		os.Exit(1)
 	}
 
+	info("Status: %s", result.Status)
+
+	if result.Failed() {
+		if result.Error != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", result.Error)
+		}
+		os.Exit(1)
+	}
+
+	info("Execution successful!")
+
 	// Show outputs
-	if config.ShowOutputs {
-		outputs := execution.GetOutputs()
-		if len(outputs) > 0 {
-			if config.JSON {
-				outputBytes, err := json.MarshalIndent(outputs, "", "  ")
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "Error formatting outputs: %v\n", err)
-				} else {
-					fmt.Println(string(outputBytes))
-				}
+	if config.ShowOutputs && len(result.Outputs) > 0 {
+		if config.JSON {
+			outputBytes, err := json.MarshalIndent(result.Outputs, "", "  ")
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error formatting outputs: %v\n", err)
 			} else {
-				fmt.Println()
-				fmt.Println("Outputs:")
-				for key, value := range outputs {
-					if valueBytes, err := json.Marshal(value); err == nil {
-						fmt.Printf("  %s: %s\n", key, string(valueBytes))
-					} else {
-						fmt.Printf("  %s: %v\n", key, value)
-					}
+				fmt.Println(string(outputBytes))
+			}
+		} else {
+			fmt.Println()
+			fmt.Println("Outputs:")
+			for key, value := range result.Outputs {
+				if valueBytes, err := json.Marshal(value); err == nil {
+					fmt.Printf("  %s: %s\n", key, string(valueBytes))
+				} else {
+					fmt.Printf("  %s: %v\n", key, value)
 				}
 			}
 		}

--- a/coverage_test.go
+++ b/coverage_test.go
@@ -571,14 +571,15 @@ func TestFileCheckpointer_DeleteCheckpoint(t *testing.T) {
 
 	// Save a checkpoint first
 	checkpoint := &Checkpoint{
-		ID:           "cp-1",
-		ExecutionID:  "exec-1",
-		WorkflowName: "test-wf",
-		Status:       "running",
-		Inputs:       map[string]any{},
-		Outputs:      map[string]any{},
-		BranchStates: map[string]*BranchState{},
-		CheckpointAt: time.Now(),
+		SchemaVersion: CheckpointSchemaVersion,
+		ID:            "cp-1",
+		ExecutionID:   "exec-1",
+		WorkflowName:  "test-wf",
+		Status:        "running",
+		Inputs:        map[string]any{},
+		Outputs:       map[string]any{},
+		BranchStates:  map[string]*BranchState{},
+		CheckpointAt:  time.Now(),
 	}
 	err = cp.SaveCheckpoint(context.Background(), checkpoint)
 	require.NoError(t, err)
@@ -604,15 +605,16 @@ func TestFileCheckpointer_ListExecutions(t *testing.T) {
 	// Save checkpoints for two executions
 	for _, execID := range []string{"exec-1", "exec-2"} {
 		checkpoint := &Checkpoint{
-			ID:           "cp-" + execID,
-			ExecutionID:  execID,
-			WorkflowName: "test-wf",
-			Status:       "completed",
-			Inputs:       map[string]any{},
-			Outputs:      map[string]any{},
-			BranchStates: map[string]*BranchState{},
-			StartTime:    time.Now(),
-			CheckpointAt: time.Now(),
+			SchemaVersion: CheckpointSchemaVersion,
+			ID:            "cp-" + execID,
+			ExecutionID:   execID,
+			WorkflowName:  "test-wf",
+			Status:        "completed",
+			Inputs:        map[string]any{},
+			Outputs:       map[string]any{},
+			BranchStates:  map[string]*BranchState{},
+			StartTime:     time.Now(),
+			CheckpointAt:  time.Now(),
 		}
 		err := cp.SaveCheckpoint(context.Background(), checkpoint)
 		require.NoError(t, err)
@@ -636,14 +638,15 @@ func TestFencedCheckpointer_DeleteCheckpoint(t *testing.T) {
 
 	// Save a checkpoint
 	checkpoint := &Checkpoint{
-		ID:           "cp-1",
-		ExecutionID:  "exec-1",
-		WorkflowName: "test-wf",
-		Status:       "running",
-		Inputs:       map[string]any{},
-		Outputs:      map[string]any{},
-		BranchStates: map[string]*BranchState{},
-		CheckpointAt: time.Now(),
+		SchemaVersion: CheckpointSchemaVersion,
+		ID:            "cp-1",
+		ExecutionID:   "exec-1",
+		WorkflowName:  "test-wf",
+		Status:        "running",
+		Inputs:        map[string]any{},
+		Outputs:       map[string]any{},
+		BranchStates:  map[string]*BranchState{},
+		CheckpointAt:  time.Now(),
 	}
 	err = fenced.SaveCheckpoint(context.Background(), checkpoint)
 	require.NoError(t, err)

--- a/docs/production_checklist.md
+++ b/docs/production_checklist.md
@@ -28,9 +28,10 @@ operational hygiene around it. This is the punch list.
 
 ## Execution
 
-- [ ] **Runner** (not bare `Execution.Execute`) is the production
-  entry point. The Runner composes heartbeat, default timeout,
-  resume, and the completion hook.
+- [ ] **Runner** is the recommended production entry point. It
+  composes heartbeat, default timeout, resume, and the completion
+  hook. Calling `Execution.Execute` directly is supported but you
+  must implement those concerns yourself.
 - [ ] `WithDefaultTimeout` is set on the Runner, or `WithRunTimeout`
   on every `Run` call. Untimed executions can wedge a worker
   indefinitely.

--- a/examples/branching/main.go
+++ b/examples/branching/main.go
@@ -244,7 +244,7 @@ func main() {
 	fmt.Println("1. Conditional branching with multiple conditions")
 	fmt.Println("2. Complex decision trees")
 	fmt.Println("3. State-based routing")
-	fmt.Println("4. Script activities for calculations")
+	fmt.Println("4. Go activities for calculations")
 	fmt.Println("5. Different execution branches based on data")
 	fmt.Println()
 

--- a/examples/error_handling/main.go
+++ b/examples/error_handling/main.go
@@ -115,13 +115,17 @@ func main() {
 	fmt.Println("Starting error handling demonstration...")
 	fmt.Println()
 
-	_, err = execution.Execute(context.Background())
+	result, err := execution.Execute(context.Background())
 	if err != nil {
 		fmt.Printf("Workflow failed: %v\n", err)
 		os.Exit(1)
 	}
+	if result.Failed() {
+		fmt.Printf("Workflow failed: %v\n", result.Error)
+		os.Exit(1)
+	}
 
 	fmt.Printf("Workflow completed successfully!\n")
-	fmt.Printf("Status: %s\n", execution.Status())
-	fmt.Printf("Final outputs: %+v\n", execution.GetOutputs())
+	fmt.Printf("Status: %s\n", result.Status)
+	fmt.Printf("Final outputs: %+v\n", result.Outputs)
 }

--- a/examples/join_branches/main.go
+++ b/examples/join_branches/main.go
@@ -121,18 +121,20 @@ func main() {
 	defer cancel()
 
 	start := time.Now()
-	_, err = execution.Execute(ctx)
+	result, err := execution.Execute(ctx)
 	duration := time.Since(start)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	if !result.Completed() {
+		log.Fatalf("workflow failed: status=%s err=%v", result.Status, result.Error)
+	}
 
 	// Print results
 	fmt.Printf("\n✅ Workflow completed in %v\n", duration)
 
-	outputs := execution.GetOutputs()
-	fmt.Printf("Final result: %v\n", outputs["final_result"])
-	fmt.Printf("Value A: %v\n", outputs["value_a"])
-	fmt.Printf("Value B: %v\n", outputs["value_b"])
+	fmt.Printf("Final result: %v\n", result.Outputs["final_result"])
+	fmt.Printf("Value A: %v\n", result.Outputs["value_a"])
+	fmt.Printf("Value B: %v\n", result.Outputs["value_b"])
 }

--- a/examples/retry_simple/main.go
+++ b/examples/retry_simple/main.go
@@ -63,11 +63,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if _, err := execution.Execute(context.Background()); err != nil {
+	result, err := execution.Execute(context.Background())
+	if err != nil {
 		log.Fatal(err)
 	}
+	if result.Failed() {
+		log.Fatalf("execution failed: %v", result.Error)
+	}
 
-	outputs, err := json.MarshalIndent(execution.GetOutputs(), "", "  ")
+	outputs, err := json.MarshalIndent(result.Outputs, "", "  ")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/execution.go
+++ b/execution.go
@@ -396,8 +396,8 @@ func (e *Execution) loadCheckpoint(ctx context.Context, priorExecutionID string)
 	if checkpoint == nil {
 		return fmt.Errorf("%w: execution %q", ErrNoCheckpoint, priorExecutionID)
 	}
-	if checkpoint.SchemaVersion > CheckpointSchemaVersion {
-		return fmt.Errorf("checkpoint schema version %d is newer than supported version %d",
+	if checkpoint.SchemaVersion < 1 || checkpoint.SchemaVersion > CheckpointSchemaVersion {
+		return fmt.Errorf("checkpoint schema version %d is not supported (supported: 1..%d)",
 			checkpoint.SchemaVersion, CheckpointSchemaVersion)
 	}
 	e.state.FromCheckpoint(checkpoint)

--- a/pause.go
+++ b/pause.go
@@ -198,6 +198,9 @@ func UnpauseBranchInCheckpoint(ctx context.Context, cp Checkpointer, executionID
 }
 
 func mutatePauseInCheckpoint(ctx context.Context, cp Checkpointer, executionID, branchID string, paused bool, reason string) error {
+	if cp == nil {
+		return fmt.Errorf("checkpointer is required")
+	}
 	apply := func(checkpoint *Checkpoint) error {
 		ps, ok := checkpoint.BranchStates[branchID]
 		if !ok {

--- a/script/eval.go
+++ b/script/eval.go
@@ -43,6 +43,11 @@ func NewTemplate(engine Compiler, raw string) (*Template, error) {
 
 	matches := templateExprRE.FindAllStringSubmatchIndex(raw, -1)
 	if len(matches) == 0 {
+		// If the string contains "${" but no valid ${...} matches were
+		// found, it has a malformed template expression.
+		if strings.Contains(raw, "${") {
+			return nil, fmt.Errorf("malformed template expression in string: %q", raw)
+		}
 		return &Template{raw: raw}, nil
 	}
 

--- a/workflowtest/memory_checkpointer.go
+++ b/workflowtest/memory_checkpointer.go
@@ -37,8 +37,8 @@ func (m *MemoryCheckpointer) LoadCheckpoint(ctx context.Context, executionID str
 	if !ok {
 		return nil, nil // Follows existing convention: nil, nil = not found
 	}
-	if cp.SchemaVersion > workflow.CheckpointSchemaVersion {
-		return nil, fmt.Errorf("checkpoint schema version %d is newer than supported version %d",
+	if cp.SchemaVersion < 1 || cp.SchemaVersion > workflow.CheckpointSchemaVersion {
+		return nil, fmt.Errorf("checkpoint schema version %d is not supported (supported: 1..%d)",
 			cp.SchemaVersion, workflow.CheckpointSchemaVersion)
 	}
 	return deepCopyCheckpoint(cp), nil

--- a/workflowtest/workflowtest_test.go
+++ b/workflowtest/workflowtest_test.go
@@ -59,9 +59,10 @@ func TestMemoryCheckpointerRoundTrips(t *testing.T) {
 
 	// Save
 	err := cp.SaveCheckpoint(ctx, &workflow.Checkpoint{
-		ExecutionID:  "exec-1",
-		WorkflowName: "test",
-		Status:       workflow.ExecutionStatusCompleted,
+		SchemaVersion: workflow.CheckpointSchemaVersion,
+		ExecutionID:   "exec-1",
+		WorkflowName:  "test",
+		Status:        workflow.ExecutionStatusCompleted,
 	})
 	require.NoError(t, err)
 
@@ -92,8 +93,9 @@ func TestMemoryCheckpointerDeepCopies(t *testing.T) {
 	ctx := context.Background()
 
 	original := &workflow.Checkpoint{
-		ExecutionID: "exec-1",
-		Inputs:      map[string]interface{}{"key": "original"},
+		SchemaVersion: workflow.CheckpointSchemaVersion,
+		ExecutionID:   "exec-1",
+		Inputs:        map[string]interface{}{"key": "original"},
 	}
 	err := cp.SaveCheckpoint(ctx, original)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Addresses the actionable feedback from CodeRabbit's review of the v1 PR (#34). Changes across 20 files:

**Critical: ExecutionResult propagation**
- CLI (`cmd/workflow/main.go`) now checks `result.Failed()` instead of only `err`
- All 4 affected examples (`join_branches`, `retry_simple`, `error_handling`, `branching`) updated to use `ExecutionResult`
- README quick-start example now declares `Outputs` so `OutputString("result")` works

**Code safety**
- `ActivityRegistry.Register` handles nil receiver and uninitialized map
- `mutatePauseInCheckpoint` guards against nil `Checkpointer`
- `ExecuteSync` propagates failed child workflow status as an error
- All checkpoint readers reject `SchemaVersion < 1` (pre-v1 checkpoints)
- `NewTemplate` rejects malformed `${...}` expressions instead of treating them as literals

**Cleanup**
- Removed dead `variablesMap()` from `BranchLocalState`
- Removed stale `wait` activity from CLI help text
- Fixed stale "Script activities" text in branching example
- Clarified `Runner` is recommended but optional in production checklist

**Test fixes**
- Replaced `require` assertions inside activity goroutines with error returns in `branch_join_test.go`
- Added `TestCheckpointOlderSchemaVersionIsRejected` test
- Updated checkpoint tests to include `SchemaVersion`

**Not addressed** (disagreed or out of scope):
- Context/ExecutionCallbacks backward compat — this is v1, the break is intentional
- `time.Duration` JSON serialization — params flow through the engine's binding system, not raw JSON
- `Each.Items` expression behavior — needs deeper investigation
- Async child workflow result storage — design change, not a quick fix
- `require` in goroutines in `execution_test.go` — pervasive pattern, needs systematic sweep
- Failure callback assertions — callbacks aren't wired up in the engine yet

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./...` succeeds (all examples compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)