### PR TITLE
002 phase 1.1+1.2: Claim carries WorkerID; fencing calls take *Claim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,22 +4,25 @@ EXPERIMENTAL_MODULES := \
 	experimental/store/postgres \
 	experimental/store/sqlite
 
-.PHONY: test
+.PHONY: all test cover test-experimental test-all clean
+
+all: test-all
+
 test:
 	go test . ./activities ./script ./workflowtest
 
-.PHONY: cover
 cover:
 	go test -coverprofile cover.out . ./activities ./script ./workflowtest
 	go tool cover -html=cover.out
 
-.PHONY: test-experimental
 test-experimental:
 	@set -e; for mod in $(EXPERIMENTAL_MODULES); do \
 		echo "==> $$mod"; \
 		(cd $$mod && go build ./... && go vet ./... && go test ./...); \
 	done
 
-.PHONY: test-all
 test-all: test test-experimental
 	go vet ./...
+
+clean:
+	rm -f cover.out

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 
+EXPERIMENTAL_MODULES := \
+	experimental/worker \
+	experimental/store/postgres \
+	experimental/store/sqlite
+
 .PHONY: test
 test:
 	go test . ./activities ./script ./workflowtest
@@ -8,6 +13,13 @@ cover:
 	go test -coverprofile cover.out . ./activities ./script ./workflowtest
 	go tool cover -html=cover.out
 
+.PHONY: test-experimental
+test-experimental:
+	@set -e; for mod in $(EXPERIMENTAL_MODULES); do \
+		echo "==> $$mod"; \
+		(cd $$mod && go build ./... && go vet ./... && go test ./...); \
+	done
+
 .PHONY: test-all
-test-all: test
+test-all: test test-experimental
 	go vet ./...

--- a/experimental/store/postgres/checkpointer.go
+++ b/experimental/store/postgres/checkpointer.go
@@ -18,25 +18,25 @@ import (
 //
 // Reads (LoadCheckpoint) are unfenced: a fresh attempt must be able
 // to resume regardless of which worker originally wrote the snapshot.
-func (s *Store) NewCheckpointer(lease worker.Lease) workflow.Checkpointer {
-	return &leasedCheckpointer{store: s, lease: lease}
+func (s *Store) NewCheckpointer(claim *worker.Claim) workflow.Checkpointer {
+	return &leasedCheckpointer{store: s, claim: claim}
 }
 
 type leasedCheckpointer struct {
 	store *Store
-	lease worker.Lease
+	claim *worker.Claim
 }
 
 // SaveCheckpoint marshals the checkpoint to JSON and writes it to the
 // workflow_runs.checkpoint column under (claimed_by, attempt) fencing.
-// The checkpoint's ExecutionID must match the lease's RunID.
+// The checkpoint's ExecutionID must match the claim's run ID.
 func (c *leasedCheckpointer) SaveCheckpoint(ctx context.Context, checkpoint *workflow.Checkpoint) error {
 	if checkpoint == nil {
 		return fmt.Errorf("postgres: nil checkpoint")
 	}
-	if checkpoint.ExecutionID != c.lease.RunID {
-		return fmt.Errorf("postgres: checkpoint execution ID %q does not match lease run ID %q",
-			checkpoint.ExecutionID, c.lease.RunID)
+	if checkpoint.ExecutionID != c.claim.ID {
+		return fmt.Errorf("postgres: checkpoint execution ID %q does not match claim run ID %q",
+			checkpoint.ExecutionID, c.claim.ID)
 	}
 	blob, err := json.Marshal(checkpoint)
 	if err != nil {
@@ -48,9 +48,9 @@ func (c *leasedCheckpointer) SaveCheckpoint(ctx context.Context, checkpoint *wor
 		WHERE id         = $2
 		  AND claimed_by = $3
 		  AND attempt    = $4
-	`, blob, c.lease.RunID, c.lease.WorkerID, c.lease.Attempt)
+	`, blob, c.claim.ID, c.claim.WorkerID, c.claim.Attempt)
 	if err != nil {
-		return fmt.Errorf("postgres: save checkpoint %s: %w", c.lease.RunID, err)
+		return fmt.Errorf("postgres: save checkpoint %s: %w", c.claim.ID, err)
 	}
 	if tag.RowsAffected() == 0 {
 		return worker.ErrLeaseLost
@@ -95,9 +95,9 @@ func (c *leasedCheckpointer) DeleteCheckpoint(ctx context.Context, executionID s
 		WHERE id         = $1
 		  AND claimed_by = $2
 		  AND attempt    = $3
-	`, c.lease.RunID, c.lease.WorkerID, c.lease.Attempt)
+	`, c.claim.ID, c.claim.WorkerID, c.claim.Attempt)
 	if err != nil {
-		return fmt.Errorf("postgres: delete checkpoint %s: %w", c.lease.RunID, err)
+		return fmt.Errorf("postgres: delete checkpoint %s: %w", c.claim.ID, err)
 	}
 	if tag.RowsAffected() == 0 {
 		return worker.ErrLeaseLost

--- a/experimental/store/postgres/queue.go
+++ b/experimental/store/postgres/queue.go
@@ -85,6 +85,7 @@ func (s *Store) ClaimQueued(ctx context.Context, workerID string) (*worker.Claim
 		ID:           id,
 		Spec:         spec,
 		Attempt:      newAttempt,
+		WorkerID:     workerID,
 		OrgID:        orgID,
 		WorkflowType: workflowType,
 		CreditCost:   creditCost,
@@ -95,7 +96,7 @@ func (s *Store) ClaimQueued(ctx context.Context, workerID string) (*worker.Claim
 // Heartbeat implements worker.QueueStore with (claimed_by, attempt)
 // fencing. Rows with a status other than running, or a mismatched
 // lease, produce ErrLeaseLost.
-func (s *Store) Heartbeat(ctx context.Context, lease worker.Lease) error {
+func (s *Store) Heartbeat(ctx context.Context, claim *worker.Claim) error {
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE workflow_runs
 		SET heartbeat_at = NOW()
@@ -103,9 +104,9 @@ func (s *Store) Heartbeat(ctx context.Context, lease worker.Lease) error {
 		  AND claimed_by = $2
 		  AND attempt    = $3
 		  AND status     = $4
-	`, lease.RunID, lease.WorkerID, lease.Attempt, string(worker.StatusRunning))
+	`, claim.ID, claim.WorkerID, claim.Attempt, string(worker.StatusRunning))
 	if err != nil {
-		return fmt.Errorf("postgres: heartbeat %s: %w", lease.RunID, err)
+		return fmt.Errorf("postgres: heartbeat %s: %w", claim.ID, err)
 	}
 	if tag.RowsAffected() == 0 {
 		return worker.ErrLeaseLost
@@ -114,7 +115,7 @@ func (s *Store) Heartbeat(ctx context.Context, lease worker.Lease) error {
 }
 
 // Complete implements worker.QueueStore with (claimed_by, attempt) fencing.
-func (s *Store) Complete(ctx context.Context, lease worker.Lease, outcome worker.Outcome) error {
+func (s *Store) Complete(ctx context.Context, claim *worker.Claim, outcome worker.Outcome) error {
 	tag, err := s.pool.Exec(ctx, `
 		UPDATE workflow_runs
 		SET status        = $1,
@@ -128,14 +129,14 @@ func (s *Store) Complete(ctx context.Context, lease worker.Lease, outcome worker
 		string(outcome.Status),
 		outcome.Result,
 		outcome.ErrorMessage,
-		lease.RunID,
-		lease.WorkerID,
+		claim.ID,
+		claim.WorkerID,
 		string(worker.StatusCompleted),
 		string(worker.StatusFailed),
-		lease.Attempt,
+		claim.Attempt,
 	)
 	if err != nil {
-		return fmt.Errorf("postgres: complete %s: %w", lease.RunID, err)
+		return fmt.Errorf("postgres: complete %s: %w", claim.ID, err)
 	}
 	if tag.RowsAffected() == 0 {
 		return worker.ErrLeaseLost

--- a/experimental/store/postgres/store_test.go
+++ b/experimental/store/postgres/store_test.go
@@ -70,6 +70,9 @@ func TestStore_EnqueueClaimCompleteRoundTrip(t *testing.T) {
 	if claim.ID != "run-a" || claim.Attempt != 1 || string(claim.Spec) != `{"type":"demo"}` {
 		t.Fatalf("unexpected claim: %+v", claim)
 	}
+	if claim.WorkerID != "test-worker" {
+		t.Fatalf("claim.WorkerID = %q, want %q", claim.WorkerID, "test-worker")
+	}
 
 	again, err := store.ClaimQueued(ctx, "test-worker")
 	if err != nil {
@@ -79,12 +82,11 @@ func TestStore_EnqueueClaimCompleteRoundTrip(t *testing.T) {
 		t.Fatalf("expected no more queued runs, got %+v", again)
 	}
 
-	lease := worker.Lease{RunID: claim.ID, WorkerID: "test-worker", Attempt: claim.Attempt}
-	if err := store.Heartbeat(ctx, lease); err != nil {
+	if err := store.Heartbeat(ctx, claim); err != nil {
 		t.Fatalf("heartbeat: %v", err)
 	}
 
-	if err := store.Complete(ctx, lease, worker.Outcome{
+	if err := store.Complete(ctx, claim, worker.Outcome{
 		Status: worker.StatusCompleted,
 		Result: []byte(`{"ok":true}`),
 	}); err != nil {
@@ -96,17 +98,24 @@ func TestStore_HeartbeatLeaseLost(t *testing.T) {
 	store, _ := openTestStore(t)
 	ctx := context.Background()
 
-	_ = store.Enqueue(ctx, worker.NewRun{ID: "run-b"})
-	claim, _ := store.ClaimQueued(ctx, "alpha")
+	if err := store.Enqueue(ctx, worker.NewRun{ID: "run-b", Spec: []byte(`{}`)}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	claim, err := store.ClaimQueued(ctx, "alpha")
+	if err != nil || claim == nil {
+		t.Fatalf("claim: %v / %+v", err, claim)
+	}
 
 	// Wrong worker ID should be rejected.
-	wrong := worker.Lease{RunID: claim.ID, WorkerID: "beta", Attempt: claim.Attempt}
-	if err := store.Heartbeat(ctx, wrong); err != worker.ErrLeaseLost {
+	wrong := *claim
+	wrong.WorkerID = "beta"
+	if err := store.Heartbeat(ctx, &wrong); err != worker.ErrLeaseLost {
 		t.Fatalf("expected ErrLeaseLost, got %v", err)
 	}
 	// Wrong attempt should be rejected.
-	badAttempt := worker.Lease{RunID: claim.ID, WorkerID: "alpha", Attempt: 99}
-	if err := store.Heartbeat(ctx, badAttempt); err != worker.ErrLeaseLost {
+	badAttempt := *claim
+	badAttempt.Attempt = 99
+	if err := store.Heartbeat(ctx, &badAttempt); err != worker.ErrLeaseLost {
 		t.Fatalf("expected ErrLeaseLost, got %v", err)
 	}
 }
@@ -115,8 +124,8 @@ func TestStore_ReclaimAndDeadLetter(t *testing.T) {
 	store, pool := openTestStore(t)
 	ctx := context.Background()
 
-	_ = store.Enqueue(ctx, worker.NewRun{ID: "reclaim-me"})
-	_ = store.Enqueue(ctx, worker.NewRun{ID: "dead-letter-me"})
+	_ = store.Enqueue(ctx, worker.NewRun{ID: "reclaim-me", Spec: []byte(`{}`)})
+	_ = store.Enqueue(ctx, worker.NewRun{ID: "dead-letter-me", Spec: []byte(`{}`)})
 
 	c1, _ := store.ClaimQueued(ctx, "w")
 	c2, _ := store.ClaimQueued(ctx, "w")
@@ -157,14 +166,10 @@ func TestStore_CheckpointerRoundTrip(t *testing.T) {
 	store, _ := openTestStore(t)
 	ctx := context.Background()
 
-	_ = store.Enqueue(ctx, worker.NewRun{ID: "cp-run"})
+	_ = store.Enqueue(ctx, worker.NewRun{ID: "cp-run", Spec: []byte(`{}`)})
 	claim, _ := store.ClaimQueued(ctx, "w")
 
-	cp := store.NewCheckpointer(worker.Lease{
-		RunID:    claim.ID,
-		WorkerID: "w",
-		Attempt:  claim.Attempt,
-	})
+	cp := store.NewCheckpointer(claim)
 
 	// Load before save -> ErrNoCheckpoint.
 	if _, err := cp.LoadCheckpoint(ctx, claim.ID); err != workflow.ErrNoCheckpoint {
@@ -192,9 +197,9 @@ func TestStore_CheckpointerRoundTrip(t *testing.T) {
 	}
 
 	// Wrong lease -> ErrLeaseLost.
-	bogus := store.NewCheckpointer(worker.Lease{
-		RunID: claim.ID, WorkerID: "someone-else", Attempt: claim.Attempt,
-	})
+	otherWorker := *claim
+	otherWorker.WorkerID = "someone-else"
+	bogus := store.NewCheckpointer(&otherWorker)
 	if err := bogus.SaveCheckpoint(ctx, original); err != worker.ErrLeaseLost {
 		t.Fatalf("expected ErrLeaseLost, got %v", err)
 	}
@@ -212,7 +217,7 @@ func TestStore_StepProgressAndActivityLog(t *testing.T) {
 	store, _ := openTestStore(t)
 	ctx := context.Background()
 
-	_ = store.Enqueue(ctx, worker.NewRun{ID: "obs-run"})
+	_ = store.Enqueue(ctx, worker.NewRun{ID: "obs-run", Spec: []byte(`{}`)})
 
 	// Step progress upsert.
 	p := workflow.StepProgress{

--- a/experimental/store/sqlite/checkpointer.go
+++ b/experimental/store/sqlite/checkpointer.go
@@ -73,17 +73,21 @@ func (c *leasedCheckpointer) LoadCheckpoint(ctx context.Context, executionID str
 }
 
 // DeleteCheckpoint implements workflow.Checkpointer with (claimed_by,
-// attempt) fencing.
+// attempt) fencing. The executionID must match the claim's run ID.
 func (c *leasedCheckpointer) DeleteCheckpoint(ctx context.Context, executionID string) error {
+	if executionID != c.claim.ID {
+		return fmt.Errorf("sqlite: execution ID %q does not match claim run ID %q",
+			executionID, c.claim.ID)
+	}
 	result, err := c.store.db.ExecContext(ctx, `
 		UPDATE workflow_runs
 		SET checkpoint = NULL
 		WHERE id         = ?
 		  AND claimed_by = ?
 		  AND attempt    = ?
-	`, c.claim.ID, c.claim.WorkerID, c.claim.Attempt)
+	`, executionID, c.claim.WorkerID, c.claim.Attempt)
 	if err != nil {
-		return fmt.Errorf("sqlite: delete checkpoint %s: %w", c.claim.ID, err)
+		return fmt.Errorf("sqlite: delete checkpoint %s: %w", executionID, err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {

--- a/experimental/store/sqlite/checkpointer.go
+++ b/experimental/store/sqlite/checkpointer.go
@@ -12,18 +12,18 @@ import (
 
 type leasedCheckpointer struct {
 	store *Store
-	lease worker.Lease
+	claim *worker.Claim
 }
 
 // SaveCheckpoint implements workflow.Checkpointer. The checkpoint's
-// ExecutionID must match the lease's RunID.
+// ExecutionID must match the claim's run ID.
 func (c *leasedCheckpointer) SaveCheckpoint(ctx context.Context, checkpoint *workflow.Checkpoint) error {
 	if checkpoint == nil {
 		return fmt.Errorf("sqlite: nil checkpoint")
 	}
-	if checkpoint.ExecutionID != c.lease.RunID {
-		return fmt.Errorf("sqlite: checkpoint execution ID %q does not match lease run ID %q",
-			checkpoint.ExecutionID, c.lease.RunID)
+	if checkpoint.ExecutionID != c.claim.ID {
+		return fmt.Errorf("sqlite: checkpoint execution ID %q does not match claim run ID %q",
+			checkpoint.ExecutionID, c.claim.ID)
 	}
 	blob, err := json.Marshal(checkpoint)
 	if err != nil {
@@ -35,9 +35,9 @@ func (c *leasedCheckpointer) SaveCheckpoint(ctx context.Context, checkpoint *wor
 		WHERE id         = ?
 		  AND claimed_by = ?
 		  AND attempt    = ?
-	`, blob, c.lease.RunID, c.lease.WorkerID, c.lease.Attempt)
+	`, blob, c.claim.ID, c.claim.WorkerID, c.claim.Attempt)
 	if err != nil {
-		return fmt.Errorf("sqlite: save checkpoint %s: %w", c.lease.RunID, err)
+		return fmt.Errorf("sqlite: save checkpoint %s: %w", c.claim.ID, err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {
@@ -81,9 +81,9 @@ func (c *leasedCheckpointer) DeleteCheckpoint(ctx context.Context, executionID s
 		WHERE id         = ?
 		  AND claimed_by = ?
 		  AND attempt    = ?
-	`, executionID, c.lease.WorkerID, c.lease.Attempt)
+	`, c.claim.ID, c.claim.WorkerID, c.claim.Attempt)
 	if err != nil {
-		return fmt.Errorf("sqlite: delete checkpoint %s: %w", executionID, err)
+		return fmt.Errorf("sqlite: delete checkpoint %s: %w", c.claim.ID, err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {

--- a/experimental/store/sqlite/queue.go
+++ b/experimental/store/sqlite/queue.go
@@ -70,6 +70,7 @@ func (s *Store) ClaimQueued(ctx context.Context, workerID string) (*worker.Claim
 		ID:           id,
 		Spec:         spec,
 		Attempt:      attempt,
+		WorkerID:     workerID,
 		OrgID:        orgID,
 		WorkflowType: workflowType,
 		CreditCost:   creditCost,
@@ -78,7 +79,7 @@ func (s *Store) ClaimQueued(ctx context.Context, workerID string) (*worker.Claim
 }
 
 // Heartbeat implements worker.QueueStore.
-func (s *Store) Heartbeat(ctx context.Context, lease worker.Lease) error {
+func (s *Store) Heartbeat(ctx context.Context, claim *worker.Claim) error {
 	now := time.Now().UTC().Format(timeFormat)
 	result, err := s.db.ExecContext(ctx, `
 		UPDATE workflow_runs
@@ -87,9 +88,9 @@ func (s *Store) Heartbeat(ctx context.Context, lease worker.Lease) error {
 		  AND claimed_by = ?
 		  AND attempt    = ?
 		  AND status     = ?
-	`, now, lease.RunID, lease.WorkerID, lease.Attempt, string(worker.StatusRunning))
+	`, now, claim.ID, claim.WorkerID, claim.Attempt, string(worker.StatusRunning))
 	if err != nil {
-		return fmt.Errorf("sqlite: heartbeat %s: %w", lease.RunID, err)
+		return fmt.Errorf("sqlite: heartbeat %s: %w", claim.ID, err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {
@@ -99,7 +100,7 @@ func (s *Store) Heartbeat(ctx context.Context, lease worker.Lease) error {
 }
 
 // Complete implements worker.QueueStore.
-func (s *Store) Complete(ctx context.Context, lease worker.Lease, outcome worker.Outcome) error {
+func (s *Store) Complete(ctx context.Context, claim *worker.Claim, outcome worker.Outcome) error {
 	completedAt := nullableTime(time.Time{})
 	if outcome.Status == worker.StatusCompleted || outcome.Status == worker.StatusFailed {
 		completedAt = nullableTime(time.Now())
@@ -118,12 +119,12 @@ func (s *Store) Complete(ctx context.Context, lease worker.Lease, outcome worker
 		outcome.Result,
 		outcome.ErrorMessage,
 		completedAt,
-		lease.RunID,
-		lease.WorkerID,
-		lease.Attempt,
+		claim.ID,
+		claim.WorkerID,
+		claim.Attempt,
 	)
 	if err != nil {
-		return fmt.Errorf("sqlite: complete %s: %w", lease.RunID, err)
+		return fmt.Errorf("sqlite: complete %s: %w", claim.ID, err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {

--- a/experimental/store/sqlite/store.go
+++ b/experimental/store/sqlite/store.go
@@ -58,8 +58,11 @@ func (s *Store) Migrate(ctx context.Context) error {
 }
 
 // NewCheckpointer returns a lease-fenced Checkpointer for the given
-// claim.
+// claim. Panics if claim is nil.
 func (s *Store) NewCheckpointer(claim *worker.Claim) *leasedCheckpointer {
+	if claim == nil {
+		panic("sqlite: nil claim")
+	}
 	return &leasedCheckpointer{store: s, claim: claim}
 }
 

--- a/experimental/store/sqlite/store.go
+++ b/experimental/store/sqlite/store.go
@@ -59,8 +59,8 @@ func (s *Store) Migrate(ctx context.Context) error {
 
 // NewCheckpointer returns a lease-fenced Checkpointer for the given
 // claim.
-func (s *Store) NewCheckpointer(lease worker.Lease) *leasedCheckpointer {
-	return &leasedCheckpointer{store: s, lease: lease}
+func (s *Store) NewCheckpointer(claim *worker.Claim) *leasedCheckpointer {
+	return &leasedCheckpointer{store: s, claim: claim}
 }
 
 func formatTime(t time.Time) string {

--- a/experimental/worker/memstore/memstore.go
+++ b/experimental/worker/memstore/memstore.go
@@ -150,6 +150,7 @@ func (s *Store) ClaimQueued(_ context.Context, workerID string) (*worker.Claim, 
 		ID:           row.id,
 		Spec:         append([]byte(nil), row.spec...),
 		Attempt:      row.attempt,
+		WorkerID:     workerID,
 		OrgID:        row.orgID,
 		WorkflowType: row.workflowType,
 		CreditCost:   row.creditCost,
@@ -158,16 +159,16 @@ func (s *Store) ClaimQueued(_ context.Context, workerID string) (*worker.Claim, 
 }
 
 // Heartbeat implements worker.QueueStore.
-func (s *Store) Heartbeat(_ context.Context, lease worker.Lease) error {
+func (s *Store) Heartbeat(_ context.Context, claim *worker.Claim) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	row, ok := s.runs[lease.RunID]
+	row, ok := s.runs[claim.ID]
 	if !ok {
 		return worker.ErrLeaseLost
 	}
 	if row.status != worker.StatusRunning ||
-		row.claimedBy != lease.WorkerID ||
-		row.attempt != lease.Attempt {
+		row.claimedBy != claim.WorkerID ||
+		row.attempt != claim.Attempt {
 		return worker.ErrLeaseLost
 	}
 	row.heartbeatAt = s.now()
@@ -175,14 +176,14 @@ func (s *Store) Heartbeat(_ context.Context, lease worker.Lease) error {
 }
 
 // Complete implements worker.QueueStore.
-func (s *Store) Complete(_ context.Context, lease worker.Lease, outcome worker.Outcome) error {
+func (s *Store) Complete(_ context.Context, claim *worker.Claim, outcome worker.Outcome) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	row, ok := s.runs[lease.RunID]
+	row, ok := s.runs[claim.ID]
 	if !ok {
 		return worker.ErrLeaseLost
 	}
-	if row.claimedBy != lease.WorkerID || row.attempt != lease.Attempt {
+	if row.claimedBy != claim.WorkerID || row.attempt != claim.Attempt {
 		return worker.ErrLeaseLost
 	}
 	row.status = outcome.Status

--- a/experimental/worker/queue_store.go
+++ b/experimental/worker/queue_store.go
@@ -82,7 +82,11 @@ type NewRun struct {
 }
 
 // Claim is a run that has been atomically claimed by a worker and
-// transitioned from StatusQueued to StatusRunning.
+// transitioned from StatusQueued to StatusRunning. A Claim is also
+// the unit of lease fencing: QueueStore writes fence on
+// (WorkerID, Attempt), and passing a *Claim into those calls gives
+// the store full access to the run's metadata without an out-of-band
+// lookup.
 type Claim struct {
 	// ID is the run's stable identifier, also used as the workflow
 	// engine's ExecutionID.
@@ -95,6 +99,10 @@ type Claim struct {
 	// Attempt = 1; each subsequent reclaim increments it.
 	Attempt int
 
+	// WorkerID is the worker that holds the lease. Populated by
+	// ClaimQueued and used for fencing subsequent writes.
+	WorkerID string
+
 	// OrgID is the organization that owns this run.
 	OrgID string
 
@@ -106,15 +114,6 @@ type Claim struct {
 
 	// CallbackURL is the webhook URL to notify on terminal status.
 	CallbackURL string
-}
-
-// Lease fences writes to a claimed run. The QueueStore must reject
-// writes whose (WorkerID, Attempt) pair does not match the current
-// claim on the run.
-type Lease struct {
-	RunID    string
-	WorkerID string
-	Attempt  int
 }
 
 // Outcome is the terminal (or dormant) state a Handler reports back
@@ -168,12 +167,12 @@ type QueueStore interface {
 	ClaimQueued(ctx context.Context, workerID string) (*Claim, error)
 
 	// Heartbeat refreshes the lease on a claimed run. Must fence on
-	// (WorkerID, Attempt) and status == StatusRunning.
-	Heartbeat(ctx context.Context, lease Lease) error
+	// (claim.WorkerID, claim.Attempt) and status == StatusRunning.
+	Heartbeat(ctx context.Context, claim *Claim) error
 
 	// Complete writes the terminal or dormant status for a claimed
-	// run. Must fence on (WorkerID, Attempt).
-	Complete(ctx context.Context, lease Lease, outcome Outcome) error
+	// run. Must fence on (claim.WorkerID, claim.Attempt).
+	Complete(ctx context.Context, claim *Claim, outcome Outcome) error
 
 	// ReclaimStale transitions StatusRunning runs whose heartbeats
 	// are older than staleBefore back to StatusQueued, for runs with

--- a/experimental/worker/worker.go
+++ b/experimental/worker/worker.go
@@ -328,17 +328,11 @@ func (w *Worker) execute(parent context.Context, claim *Claim) {
 	hbCtx, stopHeartbeat := context.WithCancel(runCtx)
 	defer stopHeartbeat()
 
-	lease := Lease{
-		RunID:    claim.ID,
-		WorkerID: w.cfg.WorkerID,
-		Attempt:  claim.Attempt,
-	}
-
 	var hbWG sync.WaitGroup
 	hbWG.Add(1)
 	go func() {
 		defer hbWG.Done()
-		w.heartbeat(hbCtx, cancelRun, lease)
+		w.heartbeat(hbCtx, cancelRun, claim)
 	}()
 
 	outcome := w.safeHandle(runCtx, claim)
@@ -363,7 +357,7 @@ func (w *Worker) execute(parent context.Context, claim *Claim) {
 	finalizeCtx, cancelFinalize := context.WithTimeout(context.Background(), finalizeTimeout)
 	defer cancelFinalize()
 
-	if err := w.store.Complete(finalizeCtx, lease, outcome); err != nil {
+	if err := w.store.Complete(finalizeCtx, claim, outcome); err != nil {
 		if errors.Is(err, ErrLeaseLost) {
 			w.cfg.Logger.Info("lease lost at completion",
 				"run_id", claim.ID, "attempt", claim.Attempt)
@@ -396,7 +390,7 @@ func (w *Worker) safeHandle(ctx context.Context, claim *Claim) (out Outcome) {
 
 // heartbeat ticks the lease forward. On ErrLeaseLost it cancels the
 // run's context so the Handler observes the loss and returns.
-func (w *Worker) heartbeat(ctx context.Context, cancelRun context.CancelFunc, lease Lease) {
+func (w *Worker) heartbeat(ctx context.Context, cancelRun context.CancelFunc, claim *Claim) {
 	ticker := time.NewTicker(w.cfg.HeartbeatInterval)
 	defer ticker.Stop()
 
@@ -405,10 +399,10 @@ func (w *Worker) heartbeat(ctx context.Context, cancelRun context.CancelFunc, le
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := w.store.Heartbeat(ctx, lease); err != nil {
+			if err := w.store.Heartbeat(ctx, claim); err != nil {
 				if errors.Is(err, ErrLeaseLost) {
 					w.cfg.Logger.Info("heartbeat: lease lost, cancelling run",
-						"run_id", lease.RunID, "attempt", lease.Attempt)
+						"run_id", claim.ID, "attempt", claim.Attempt)
 					cancelRun()
 					return
 				}
@@ -416,7 +410,7 @@ func (w *Worker) heartbeat(ctx context.Context, cancelRun context.CancelFunc, le
 				// next tick. The reaper will eventually reclaim
 				// the run if the heartbeats never recover.
 				w.cfg.Logger.Warn("heartbeat failed",
-					"run_id", lease.RunID, "error", err)
+					"run_id", claim.ID, "error", err)
 			}
 		}
 	}

--- a/planning/specs/002-worker-store-improvements.md
+++ b/planning/specs/002-worker-store-improvements.md
@@ -1,0 +1,610 @@
+# Spec: Worker & Postgres Store Improvements
+
+_Status: Draft_
+_Created: 2026-04-12_
+_Source: NoodleSpy spike branch `spike/workflow-v002-worker-pgstore` (research doc 025)_
+
+---
+
+## Goal
+
+Make `experimental/worker` and `experimental/store/postgres` carry more of the
+production workload so consumers can ship a workflow system with minimal glue
+code. Concretely: eliminate the ~420-line adapter layer NoodleSpy needed to
+bridge the library to its existing repos, and let any consumer drop their
+parallel "workflows" table in favor of `workflow_runs` as the system of record.
+
+The library is still a pure execution engine at its core. The experimental
+submodules are where we own persistence, leasing, and reconciliation —
+this spec is about making that ownership feel complete.
+
+## Design Principles
+
+1. **Experimental submodules can break.** `experimental/worker` and
+   `experimental/store/postgres` are pre-1.0 by design. Now is the time to
+   churn the interfaces; tagging happens after the dust settles.
+2. **Don't bake consumer-specific domain into the library.** Org and project
+   are the universal B2B partition pattern and earn first-class fields.
+   Everything else goes in `Metadata`.
+3. **Provide an escape hatch.** `Store.Pool()` lets consumers run any query
+   the high-level API doesn't cover. The bar for adding a new high-level
+   method is "many consumers will want this," not "one consumer needs it."
+4. **Workers should be self-sufficient.** A Handler should receive everything
+   it needs to run a workflow as inputs — no DB round-trips to fetch
+   metadata, no manually constructed checkpointers, no lease wiring.
+5. **Nullable means nullable.** Single-tenant deployments shouldn't invent
+   sentinel org IDs. Empty string in the Go API ↔ NULL in the database.
+
+---
+
+## Phase 1: Quick Wins
+
+These are independent, small, and unblock the rest. Each is a separate PR.
+
+### 1.1 `WorkerID` on `Claim`
+
+**File:** `experimental/worker/queue_store.go`
+
+Add `WorkerID string` to `Claim`. The worker already has `w.cfg.WorkerID` in
+scope when it constructs the claim in `claimBatch`; populate it there.
+
+```go
+type Claim struct {
+    // ... existing fields ...
+    WorkerID string // the worker that holds the lease
+}
+```
+
+The postgres `ClaimQueued` already records `claimed_by` in the row; just
+read it back into the returned `Claim`.
+
+**Impact.** Handlers no longer need to round-trip the DB to fence their own
+writes. Removes ~10 lines from a typical Handler.
+
+---
+
+### 1.2 Pass `*Claim` to `Complete` and `Heartbeat`
+
+**File:** `experimental/worker/queue_store.go`, `worker.go`
+
+Replace the `Lease`-only signatures with `*Claim`. The worker has the claim
+in scope at every call site already.
+
+```go
+type QueueStore interface {
+    // ...
+    Heartbeat(ctx context.Context, claim *Claim) error
+    Complete(ctx context.Context, claim *Claim, outcome Outcome) error
+    // ...
+}
+```
+
+Fencing is still on `(WorkerID, Attempt)` — the new signature is purely about
+giving the store access to `OrgID`, `ProjectID`, `WorkflowType`, and
+`CreditCost` without an out-of-band cache.
+
+`Lease` as a type can either go away entirely or stay as an internal helper.
+Recommend deleting it; it adds nothing once `*Claim` is the unit of currency.
+
+**Impact.** Eliminates the `sync.Map` `runID → orgID` cache pattern in
+consumer adapters. Future additions to `Claim` automatically reach all
+fencing call sites without interface churn.
+
+---
+
+### 1.3 `WebhookDelivererFunc` adapter
+
+**File:** `experimental/worker/webhooks.go`
+
+```go
+type WebhookDelivererFunc func(ctx context.Context, url string, payload []byte) error
+
+func (f WebhookDelivererFunc) Deliver(ctx context.Context, url string, payload []byte) error {
+    return f(ctx, url, payload)
+}
+```
+
+Five lines. Matches the `HandlerFunc` pattern already in the package.
+
+---
+
+### 1.4 Worker-side ID generation for outbox values
+
+**File:** `experimental/worker/worker.go`, `subsystems.go`
+
+Add an `IDGenerator func() string` field to `Config`. Default to
+`uuid.NewString()` (the worker package can take the UUID dep — it's already
+implicit through stdlib `crypto/rand` if we want to avoid the dependency,
+but `github.com/google/uuid` is fine for the experimental submodule).
+
+Populate `Trigger.ID` and `WebhookDelivery.ID` in `afterComplete` before
+calling `InsertTriggers` / `EnqueueWebhook`.
+
+The postgres store should honor a non-empty ID and only generate one when
+the field is blank — this keeps existing behavior working and lets
+consumers with custom ID schemes plug them in.
+
+**Impact.** Consumer-side store adapters lose their `idGen` constructor
+parameter. `InsertTriggers` and `EnqueueWebhook` become pure pass-throughs.
+
+---
+
+### 1.5 `Store.Pool()` escape hatch
+
+**File:** `experimental/store/postgres/store.go`
+
+```go
+// Pool returns the underlying pgxpool.Pool for queries the high-level API
+// does not cover. Consumers are responsible for not breaking the store's
+// invariants (lease fencing, status transitions, etc.).
+func (s *Store) Pool() *pgxpool.Pool { return s.pool }
+```
+
+Document the invariants the store maintains so consumers know what they
+can and can't do via raw queries.
+
+**Impact.** Consumers can do dedup checks, custom analytics queries,
+joined reads, and one-off migrations without forking the library or
+adding methods that won't generalize.
+
+---
+
+### 1.6 Configurable table prefix
+
+**File:** `experimental/store/postgres/store.go`, `schema.sql`
+
+```go
+postgres.New(pool,
+    postgres.WithLogger(logger),
+    postgres.WithTablePrefix("dn_"),
+)
+```
+
+Default prefix: empty string, matching today's `workflow_runs` /
+`workflow_events` / etc. naming. Consumers with collisions pick a prefix.
+
+`schema.sql` becomes a Go template (or generated string) so prefix
+substitution happens at migration time.
+
+All `Store` queries reference table names through a helper that prepends
+the prefix — there's no clean way around touching every query, but it's
+mechanical.
+
+**Impact.** Consumers migrating from existing schemas can pick a non-
+colliding prefix. NoodleSpy's `workflow_events`/`workflow_triggers`/
+`workflow_webhooks` collision goes away.
+
+---
+
+## Phase 2: Correctness Fix
+
+### 2.1 `DeadLetterStale` triggers credit refunds inline
+
+**Files:** `experimental/worker/queue_store.go`, `worker.go`
+
+Change `DeadLetterStale` to return `[]DeadLetteredRun` with the metadata
+needed for refund:
+
+```go
+type DeadLetteredRun struct {
+    ID           string
+    OrgID        string
+    WorkflowType string
+    CreditCost   int
+}
+
+DeadLetterStale(
+    ctx context.Context,
+    staleBefore time.Time,
+    maxAttempts int,
+    excludeIDs []string,
+) ([]DeadLetteredRun, error)
+```
+
+In `reapOnce`, call `CreditStore.Refund` for each dead-lettered run before
+emitting the dead-letter event.
+
+**Impact.** Refunds happen immediately on dead-letter instead of waiting
+up to 5 minutes for the reconcile loop. Closes a user-visible latency gap
+and a class of "where did my credit go" bugs.
+
+---
+
+## Phase 3: Reconcile Cleanup
+
+### 3.1 Move `ListFailedWithCredits` to `QueueStore`
+
+**Files:** `experimental/worker/queue_store.go`, `credits.go`, `worker.go`
+
+Remove `CreditStore.ListUnrefunded`. `CreditStore` becomes pure ledger
+operations: `Debit`, `Refund`, `HasRefund`, `Balance`.
+
+Add to `QueueStore`:
+
+```go
+type FailedRun struct {
+    ID           string
+    OrgID        string
+    WorkflowType string
+    CreditCost   int
+}
+
+ListFailedWithCredits(ctx context.Context, limit int) ([]FailedRun, error)
+```
+
+Update `reconcileLoop` to query `QueueStore.ListFailedWithCredits`, then
+check `CreditStore.HasRefund` per row, then `Refund` if missing.
+
+**Impact.** Cross-concern query goes away. Consumer credit adapters lose
+their dependency on workflow repos. The reconcile loop owns the cross-
+table logic where it belongs.
+
+---
+
+## Phase 4: Org & Project — Nullable Partitions and Worker Scoping
+
+### 4.1 Nullable `OrgID`, new nullable `ProjectID`
+
+**Files:** `experimental/worker/queue_store.go`,
+`experimental/store/postgres/schema.sql`, `queue.go`
+
+Add `ProjectID string` to `NewRun` and `Claim`. Both `OrgID` and `ProjectID`
+are nullable in the database; the Go API uses empty string as the NULL
+sentinel (no `*string`, no `sql.NullString` in the public surface).
+
+```go
+type NewRun struct {
+    ID           string
+    Spec         []byte
+    OrgID        string // empty = NULL
+    ProjectID    string // empty = NULL
+    ParentRunID  string // empty = NULL
+    WorkflowType string
+    InitiatedBy  string
+    CreditCost   int
+    CallbackURL  string
+    Metadata     map[string]string // arbitrary, JSONB-backed
+}
+
+type Claim struct {
+    ID           string
+    Spec         []byte
+    Attempt      int
+    WorkerID     string
+    OrgID        string
+    ProjectID    string
+    ParentRunID  string
+    WorkflowType string
+    InitiatedBy  string
+    CreditCost   int
+    CallbackURL  string
+    CreatedAt    time.Time
+    Metadata     map[string]string
+}
+```
+
+Naming rationale for `ProjectID`: the org→project pattern is the dominant
+B2B partition shape (GCP projects, Linear teams, Notion workspaces, GitHub
+repos-within-org). The library does not enforce or interpret it — purely
+stores, indexes, and filters. Consumers whose product calls it something
+else (workspace, team, board) store their internal ID in the column and
+rename it in their UI layer.
+
+`ParentRunID` earns a real column because child workflows are already a
+library concept (the trigger outbox).
+
+`Metadata` is the catch-all for anything else: tenant-specific tags,
+correlation IDs, feature flags, etc. JSONB column with a GIN index for
+containment queries.
+
+DDL:
+
+```sql
+ALTER TABLE workflow_runs
+    ALTER COLUMN org_id DROP NOT NULL,
+    ALTER COLUMN org_id DROP DEFAULT;
+
+ALTER TABLE workflow_runs
+    ADD COLUMN IF NOT EXISTS project_id    TEXT,
+    ADD COLUMN IF NOT EXISTS parent_run_id TEXT,
+    ADD COLUMN IF NOT EXISTS metadata      JSONB;
+
+CREATE INDEX IF NOT EXISTS workflow_runs_org_project_created
+    ON workflow_runs (org_id, project_id, created_at DESC)
+    WHERE project_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS workflow_runs_parent_created
+    ON workflow_runs (parent_run_id, created_at DESC)
+    WHERE parent_run_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS workflow_runs_metadata_gin
+    ON workflow_runs USING GIN (metadata);
+```
+
+The Go layer converts `""` ↔ `NULL` at the storage boundary. Consumers
+never see `*string`.
+
+---
+
+### 4.2 Worker scoping via `ClaimFilter`
+
+**Files:** `experimental/worker/queue_store.go`, `worker.go`,
+`experimental/store/postgres/queue.go`
+
+Workers can restrict which queued runs they claim. Operational use cases:
+dedicated tenant pools, project-level resource isolation, geographic or
+compliance affinity, priority lanes.
+
+```go
+type ClaimFilter struct {
+    OrgID     string // empty = any (including NULL)
+    ProjectID string // empty = any (including NULL)
+}
+
+type QueueStore interface {
+    ClaimQueued(ctx context.Context, workerID string, filter ClaimFilter) (*Claim, error)
+    // ...
+}
+
+type Config struct {
+    // ...
+    // ClaimFilter optionally restricts which queued runs this worker
+    // will claim. Zero value matches any run. Multiple workers with
+    // different filters can share a queue for tenant or project isolation.
+    ClaimFilter ClaimFilter
+}
+```
+
+Postgres implementation:
+
+```sql
+SELECT ... FROM workflow_runs
+WHERE status = 'queued'
+  AND ($1 = '' OR org_id     = $1)
+  AND ($2 = '' OR project_id = $2)
+ORDER BY created_at
+FOR UPDATE SKIP LOCKED
+LIMIT 1
+```
+
+Add `(org_id, project_id, status, created_at)` index to keep filtered claim
+latency flat under load.
+
+**Semantic note.** Empty filter means "any value, including NULL." This is
+the right default for the common single-pool case. There is intentionally
+no way through the high-level filter to say "only NULL orgs" or "only
+non-NULL orgs" — consumers with that need go through `Pool()`.
+
+**Future extension (do not build now).** A slice of filters would let one
+worker claim from multiple orgs but not all. Defer until a real consumer
+asks; running multiple worker instances with single filters covers the
+gap in the meantime.
+
+---
+
+## Phase 5: HandlerContext — Pre-fenced Stores
+
+### 5.1 Replace `Handler.Handle(ctx, *Claim)` with `Handle(ctx, *HandlerContext)`
+
+**Files:** `experimental/worker/handler.go`, `worker.go`
+
+The biggest single ergonomic improvement in the spec. Today every consumer
+constructs a `DBCheckpointer`, wires up `StepProgressCallbacks`, and passes
+them into `workflow.Execute()` themselves. The worker already has all the
+inputs — it should hand the Handler a fully-configured context.
+
+```go
+type HandlerContext struct {
+    Claim          *Claim
+    Checkpointer   workflow.Checkpointer       // pre-fenced on this lease
+    ProgressStore  workflow.StepProgressStore  // pre-fenced on this lease
+    ActivityLogger workflow.ActivityLogger     // optional
+    SignalStore    workflow.SignalStore        // optional
+}
+
+type Handler interface {
+    Handle(ctx context.Context, hc *HandlerContext) Outcome
+}
+
+type HandlerFunc func(ctx context.Context, hc *HandlerContext) Outcome
+func (f HandlerFunc) Handle(ctx context.Context, hc *HandlerContext) Outcome {
+    return f(ctx, hc)
+}
+```
+
+The postgres store gains constructors that produce pre-fenced wrappers:
+
+```go
+func (s *Store) NewCheckpointer(claim *Claim) workflow.Checkpointer
+func (s *Store) NewStepProgressStore(claim *Claim) workflow.StepProgressStore
+func (s *Store) NewActivityLogger(claim *Claim) workflow.ActivityLogger
+```
+
+Each wrapper carries the `(WorkerID, Attempt)` from the claim and fences
+every write. Lease loss surfaces as `ErrLeaseLost` from the underlying
+store call.
+
+Worker wiring (in `execute`):
+
+```go
+hc := &HandlerContext{
+    Claim:          claim,
+    Checkpointer:   w.cfg.Store.NewCheckpointer(claim),
+    ProgressStore:  w.cfg.Store.NewStepProgressStore(claim),
+    ActivityLogger: w.cfg.Store.NewActivityLogger(claim),
+}
+outcome := w.safeHandle(runCtx, hc)
+```
+
+The Handler becomes a pure "given a workflow def + inputs, run them"
+function. No persistence wiring in consumer code.
+
+For consumers using a non-postgres store, they implement the same
+factory methods on their own store type.
+
+**Impact.** Removes ~250 lines of `DBCheckpointer` / `StepProgressCallbacks`
+boilerplate from a typical consumer. This is the change that makes the
+worker package feel like a framework instead of a parts kit.
+
+---
+
+## Phase 6: Read-Side Run API
+
+### 6.1 `Run` type
+
+**File:** `experimental/store/postgres/runs.go` (new)
+
+```go
+type Run struct {
+    ID           string
+    OrgID        string
+    ProjectID    string
+    ParentRunID  string
+    WorkflowType string
+    Status       worker.Status
+    CreditCost   int
+    InitiatedBy  string
+    CallbackURL  string
+    Spec         []byte
+    Result       []byte
+    ErrorMessage string
+    CurrentStep  string
+    Metadata     map[string]string
+    Attempt      int
+    ClaimedBy    string
+    HeartbeatAt  *time.Time
+    CreatedAt    time.Time
+    StartedAt    *time.Time
+    CompletedAt  *time.Time
+}
+```
+
+**Deliberate omissions vs research doc 025:**
+
+- No `StepProgress []byte` denormalized blob. The existing
+  `workflow_step_progress` table is the single source of truth. Consumers
+  who want a per-run summary join against it or use `Pool()`.
+
+### 6.2 `RunFilter` and `RunCursor`
+
+```go
+type RunFilter struct {
+    WorkflowType string            // empty = all types
+    Status       worker.Status     // empty = all statuses
+    ProjectID    string            // empty = all projects (incl NULL)
+    ParentRunID  string            // empty = all parents
+    InitiatedBy  string            // empty = all initiators
+    Metadata     map[string]string // JSONB containment match
+    Cursor       *RunCursor        // nil = start from newest
+    Limit        int               // 0 = default (50)
+}
+
+type RunCursor struct {
+    CreatedAt time.Time
+    ID        string
+}
+```
+
+Keyset pagination on `(created_at DESC, id DESC)`. Cursor is opaque to
+consumers; recommend they base64-encode it for API transport.
+
+### 6.3 Read methods on `Store`
+
+```go
+var ErrRunNotFound = errors.New("postgres: run not found")
+
+func (s *Store) GetRun(ctx context.Context, orgID, id string) (*Run, error)
+func (s *Store) ListRuns(ctx context.Context, orgID string, filter RunFilter) ([]*Run, *RunCursor, error)
+func (s *Store) CountRuns(ctx context.Context, orgID string, filter RunFilter) (int, error)
+func (s *Store) DeleteRun(ctx context.Context, orgID, id string) error
+```
+
+`orgID == ""` is a valid scope (single-tenant); the store passes it through
+to the WHERE clause as `org_id IS NULL`.
+
+`DeleteRun` fails if the run is `StatusRunning`. Caller must cancel/complete
+it first. (We may want a `CancelRun` method too — flag for follow-up.)
+
+**Scope discipline.** This API exists to support operational dashboards and
+run management. Document explicitly that complex analytics queries (date
+ranges, aggregations, full-text search on errors) should use `Pool()`
+directly. The bar for adding a new high-level read method is "many
+consumers will want this," not "one consumer needs it."
+
+---
+
+## Phase 7: Tag and Publish
+
+### 7.1 Published submodule tags
+
+After Phases 1–6 land and stabilize:
+
+```
+git tag experimental/worker/v0.1.0
+git tag experimental/store/postgres/v0.1.0
+git push --tags
+```
+
+Consumers can drop their `replace` directives and pin versions normally.
+
+The `v0.1.0` (not `v1.0.0`) signal stays — we've just done a round of
+breaking changes and shouldn't pretend the API is stable yet.
+
+---
+
+## Out of Scope
+
+These came up in discussion and are deliberately not in this spec:
+
+- **Multi-filter worker scoping.** A single `ClaimFilter` per worker
+  handles the 90% case. Slice-of-filters waits for a real ask.
+- **Library-side enforcement of org/project scoping.** The library stores
+  and indexes them but does not enforce cross-tenant isolation, project-
+  level rate limits, or project-level credit accounting. Consumer concern.
+- **Webhook SSRF protection and HMAC signing.** Genuinely consumer-specific.
+  `WebhookDelivererFunc` (1.3) is the integration point.
+- **Dedup queries like `ExistsActiveForSpec`.** Consumer-specific JSONB
+  predicates. `Pool()` (1.5) is the integration point.
+- **`CancelRun` method.** Probably wanted, but design needs its own pass —
+  graceful vs. forced, in-flight vs. queued, lease semantics.
+- **Replacing the bundled SQLite store.** Same interfaces apply; bring it
+  in line in a follow-up.
+
+---
+
+## Sequencing
+
+Phases are roughly ordered by dependency and risk:
+
+1. **Phase 1** (quick wins) — independent PRs, ship in any order. Low risk.
+2. **Phase 2** (dead-letter refunds) — depends on no other phase. Closes a
+   correctness gap; do it early.
+3. **Phase 3** (reconcile cleanup) — independent. Cleanup after Phase 2.
+4. **Phase 4** (org/project + ClaimFilter) — schema migration; coordinate
+   with anyone running the postgres store in production.
+5. **Phase 5** (HandlerContext) — biggest UX win, breaks `Handler` interface.
+   Land after Phase 4 so the new `Claim` shape is in place.
+6. **Phase 6** (read-side API) — depends on Phase 4 (Run shape mirrors
+   Claim). Ship after Phase 5 stabilizes.
+7. **Phase 7** (tag) — only after the above settles.
+
+Estimated total: ~400 lines added to the library, ~2,000 lines deleted from
+a typical consumer. Net win for everyone.
+
+---
+
+## Open Questions
+
+1. **UUID dependency.** Phase 1.4 wants a default ID generator. Take
+   `github.com/google/uuid` as a dep on `experimental/worker`, or roll our
+   own with `crypto/rand`? Lean: take the dep, it's experimental.
+2. **`Lease` type fate.** Phase 1.2 makes `*Claim` the unit of fencing.
+   Delete `Lease` entirely, or keep it as an internal helper? Lean: delete.
+3. **Metadata column type.** `JSONB map[string]string` or `JSONB []byte`
+   (consumer-controlled marshaling)? Lean: `map[string]string` — covers
+   the common case, escape hatch via `Pool()` for richer shapes.
+4. **`workflow.SignalStore` on `HandlerContext`.** Worth pre-wiring, or
+   leave to consumers? Lean: pre-wire; signals are a library concept.
+5. **Read API location.** Methods on `*postgres.Store` directly, or a
+   `RunReader` interface that the store implements? Lean: methods on
+   `Store`, add an interface later if a second backend appears.


### PR DESCRIPTION
## Summary

Implements **Phase 1.1 + 1.2** of [`planning/specs/002-worker-store-improvements.md`](planning/specs/002-worker-store-improvements.md). Also lands the spec itself so subsequent PRs in this chain can reference it on main.

- `Claim` gains a `WorkerID` field populated by `ClaimQueued`.
- `QueueStore.Heartbeat` and `QueueStore.Complete` take `*Claim` instead of a separate `Lease`. The `Lease` type is deleted.
- `postgres.Store.NewCheckpointer` now takes `*Claim`.

Fencing is still `(WorkerID, Attempt)` — the change is purely about giving stores full access to run metadata (OrgID, WorkflowType, CreditCost, CallbackURL) without an out-of-band cache. This eliminates a common adapter pattern in consumer code.

## Open question decisions

- **Q2 (Lease type fate): delete.** Went with the spec's lean recommendation. Nothing references `Lease` internally anymore.

## Drive-by fix

`TestStore_*` in the postgres submodule were passing `worker.NewRun{ID: "..."}` with a nil `Spec`, which violates the `NOT NULL spec` column. The tests were latent-broken because CI skips postgres tests without a DSN. Fixed by supplying an empty JSON spec blob in the affected tests.

## Test plan

- [x] `make test-all` (root module)
- [x] `go test ./...` in `experimental/worker`
- [x] `WORKFLOW_PG_DSN=... go test ./...` in `experimental/store/postgres` against a real Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched queue/lease handling to a richer claim object (includes worker identity and attempt) and updated lifecycle and checkpointing flows to use it.
* **Tests**
  * Updated store and worker tests to exercise the claim-based flow and fencing behaviors.
* **Chore**
  * Added experimental modules to CI/test workflow.
* **Documentation**
  * Added a spec outlining phased improvements to worker/store design and APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->