### PR TITLE
docs: refresh README and CLAUDE.md after recent worker/store updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,12 +3,13 @@
 Go library for defining and executing multi-step processes as directed graphs.
 Module: `github.com/deepnoodle-ai/workflow`
 
-Read `llms.txt` for the full API reference.
+Read `llms.txt` for the full API reference. The friendly tour lives in
+`documentation/` and `README.md`.
 
 ## Scope
 
-This is a **pure execution engine**. It runs workflows in-process and provides
-interfaces for the things it doesn't own. What it does and doesn't do:
+This is a **pure execution engine**. It runs workflows in-process and lets
+consumers plug in everything else.
 
 **Does**: Define workflows as step graphs. Execute steps (activities). Branch
 and join execution paths. Retry with backoff. Catch and route errors. Checkpoint
@@ -20,12 +21,11 @@ parameter templates via a bundled expression engine
 **Does not**: Store workflows, checkpoints, or progress. Queue or schedule work.
 Manage distributed workers or leases. Provide a database, API, or UI.
 
-Storage is the consumer's responsibility. The library defines interfaces
+Storage is the consumer's problem. The library defines interfaces
 (`Checkpointer`, `StepProgressStore`, `ActivityLogger`, `SignalStore`,
-`WorkflowRegistry`) and the consumer provides implementations backed by their
-own infrastructure (Postgres, Redis, S3, etc.). The built-in
-`FileCheckpointer` and `MemoryCheckpointer` exist for development and testing
-only.
+`WorkflowRegistry`) and the consumer plugs in whatever they like (Postgres,
+Redis, S3, etc.). The built-in `FileCheckpointer` and `MemoryCheckpointer` are
+for development and testing.
 
 ## How Branch Execution Works
 
@@ -104,20 +104,31 @@ Experimental submodules (separate `go.mod`, not imported by the root module):
 
 - `experimental/worker/` — queue-backed durable worker (claim loop, heartbeat,
   reaper, credit reconciler). Defines the `QueueStore` and `HandlerStores`
-  interfaces. Handlers receive a `*HandlerContext` carrying the `Claim` plus
-  optional pre-fenced `Checkpointer`, `StepProgressStore`, `ActivityLogger`,
-  and `SignalStore`. IDs for outbox rows (triggers, webhooks) are generated
-  worker-side via `Config.IDGenerator`.
+  interfaces. `Claim` carries `WorkerID`, `ProjectID`, `ParentRunID`,
+  `InitiatedBy`, and `Metadata`. Handlers receive a `*HandlerContext` carrying
+  the `Claim` plus optional pre-fenced `Checkpointer`, `StepProgressStore`,
+  `ActivityLogger`, and `SignalStore` — only `Checkpointer` is lease-fenced;
+  the others accept `*Claim` for API symmetry. `SignalStore` is shared across
+  claims and lives on `Config`, not the factory. Outbox row IDs (triggers,
+  webhooks) are generated worker-side via `Config.IDGenerator`.
+- `experimental/worker/runquery/` — backend-neutral run query package
+  (stdlib-only) that holds `Run`, `RunFilter`, `RunCursor`, `ErrRunNotFound`,
+  `ErrCannotDeleteRunning`, and the `Store` interface. Dashboards depend on
+  this package instead of importing a specific store implementation.
 - `experimental/store/postgres/` — pgx-backed persistence implementing
-  `Checkpointer`, `StepProgressStore`, `ActivityLogger`, `CreditStore`, and
-  `QueueStore`. Exposes a read-side `Run` API (`GetRun`, `ListRuns`,
-  `CountRuns`, `DeleteRun`) for operational dashboards. Schema namespace is
-  configurable via `WithSchema(...)`; defaults to `"public"`. `Migrate` issues
-  `CREATE SCHEMA IF NOT EXISTS` and templates `schema.sql` with the chosen
-  schema. Schema names are validated as simple SQL identifiers.
-- `experimental/store/sqlite/` — database/sql-backed persistence with the same
-  interface surface. Single-writer, suitable for dev/testing and single-process
-  deployments.
+  `Checkpointer`, `StepProgressStore`, `ActivityLogger`, `CreditStore`,
+  `QueueStore`, and `runquery.Store` (`GetRun`, `ListRuns` with keyset
+  pagination + metadata JSONB containment, `CountRuns`, `DeleteRun`).
+  `DeleteRun` is a single atomic statement that refuses running runs.
+  Schema namespace is configurable via `WithSchema(...)`; defaults to
+  `"public"`. `Migrate` issues `CREATE SCHEMA IF NOT EXISTS` and templates
+  `schema.sql` with the chosen schema. Schema names are validated as simple
+  SQL identifiers. The migration carries forward v0.0.3 single-tenant rows
+  by rewriting empty-string `org_id`/`initiated_by` to `NULL`.
+- `experimental/store/sqlite/` — `database/sql`-backed persistence with the
+  same interface surface. Single-writer, suitable for dev/testing and
+  single-process deployments. No schema namespacing escape hatch — consumers
+  who need coexistence should hand the library a dedicated `*sql.DB`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # Workflow
 
-A Go library for defining and executing multi-step processes as
-directed graphs. Conditional branching, parallel execution,
-expression-driven templating, durable checkpointing, and
-suspend/resume on signals or wall-clock waits.
+A Go library for defining and running multi-step processes as
+directed graphs. You get conditional branching, parallel execution,
+expression-driven templates, durable checkpointing, and the ability
+to suspend and resume on signals or wall-clock waits.
 
 Think of it like a lightweight hybrid of Temporal and AWS Step
-Functions, with everything that doesn't belong inside an execution
-engine pushed out to interfaces consumers implement.
+Functions. The execution engine is all that lives inside; everything
+that doesn't belong inside an engine — storage, queues, leasing — is
+an interface you implement however you like.
 
 Edge conditions and `${...}` parameter templates are evaluated by
 [`github.com/deepnoodle-ai/expr`](https://github.com/deepnoodle-ai/expr),
 a small zero-dependency expression evaluator with a Go-like syntax.
-It is the only external dependency of the root module.
+It's the only external dependency of the root module.
 
 ## Main concepts
 
-| Concept        | Description                                                                            |
-| -------------- | -------------------------------------------------------------------------------------- |
-| **Workflow**   | A repeatable process defined as a directed graph of steps                              |
-| **Step**       | A node in the graph — runs an activity, joins branches, sleeps, waits, or pauses      |
-| **Activity**   | A function that performs the actual work                                               |
-| **Edge**       | Defines flow between steps, optionally guarded by a condition                          |
-| **Execution** | A single run of a workflow, with its own state                                         |
-| **Branch**     | An independent execution thread with its own copy of state                             |
-| **State**      | Branch-local mutable variables that activities read and write                          |
-| **Runner**     | Production entry point that composes heartbeat, timeout, resume, and completion hooks |
+| Concept       | Description                                                                       |
+| ------------- | --------------------------------------------------------------------------------- |
+| **Workflow**  | A repeatable process defined as a directed graph of steps                         |
+| **Step**      | A node in the graph — runs an activity, joins branches, sleeps, waits, or pauses  |
+| **Activity**  | A function that performs the actual work                                          |
+| **Edge**      | Defines flow between steps, optionally guarded by a condition                     |
+| **Execution** | A single run of a workflow, with its own state                                    |
+| **Branch**    | An independent execution thread with its own copy of state                        |
+| **State**     | Branch-local mutable variables that activities read and write                     |
+| **Runner**    | Convenience entry point that composes heartbeat, timeout, resume, and hooks       |
 
 ## Quick example
 
@@ -104,46 +105,57 @@ func main() {
 }
 ```
 
-The `Runner` is the recommended entry point for production code. It
-composes heartbeating, default timeouts, resume-from-checkpoint, and
-completion hooks. For one-shot scripts and tests, calling
-`exec.Execute(ctx)` directly is fine.
+For one-shot scripts and tests, calling `exec.Execute(ctx)` directly
+is perfectly fine. The `Runner` is the convenient wrapper when you
+also want heartbeating, default timeouts, resume-from-checkpoint, and
+completion hooks.
 
-## Going to production
+## Bring your own storage
 
-The library is a pure execution engine. Storage, scheduling, signal
-delivery, and worker leasing are the consumer's responsibility — the
-library defines interfaces (`Checkpointer`, `StepProgressStore`,
-`ActivityLogger`, `SignalStore`, `WorkflowRegistry`) and you wire
-your own backends. The bundled `MemoryCheckpointer` and
-`FileCheckpointer` are for development only.
+The library is a pure execution engine — it doesn't ship a database,
+a queue, or a UI, and it never will. Instead it defines small
+interfaces (`Checkpointer`, `StepProgressStore`, `ActivityLogger`,
+`SignalStore`, `WorkflowRegistry`) and you wire up whatever backends
+fit your stack. The bundled `MemoryCheckpointer` and
+`FileCheckpointer` are great for development and tests.
 
-See [`docs/production_checklist.md`](docs/production_checklist.md)
-for the full punch list, and [`docs/suspension.md`](docs/suspension.md)
-for the suspend / resume / replay-safety contract.
+If you'd rather not start from scratch, the `experimental/`
+submodules give you a head start:
 
-For a turnkey queue-backed runner and persistence backends, see
-[`docs/worker.md`](docs/worker.md) and
-[`docs/postgres.md`](docs/postgres.md). The
-[`experimental/worker/`](experimental/worker/),
-[`experimental/store/postgres/`](experimental/store/postgres/), and
-[`experimental/store/sqlite/`](experimental/store/sqlite/)
-submodules ship with this repo but live in their own Go modules so
-the root module stays stdlib-only. Everything under `experimental/`
-is functional but the API is not yet stable.
+- [`experimental/worker/`](experimental/worker/) — a queue-backed
+  durable worker with claim loop, heartbeat, reaper, and credit
+  reconciliation. Handlers receive a `*HandlerContext` carrying the
+  current `Claim` plus pre-fenced stores. The
+  [`runquery`](experimental/worker/runquery/) subpackage exposes a
+  backend-neutral read API (`GetRun`, `ListRuns`, `CountRuns`,
+  `DeleteRun`) so dashboards can stay storage-agnostic.
+- [`experimental/store/postgres/`](experimental/store/postgres/) —
+  pgx-backed persistence that implements every store interface plus
+  `runquery.Store`. Schema namespace is configurable via
+  `WithSchema(...)` so it can live alongside other tables.
+- [`experimental/store/sqlite/`](experimental/store/sqlite/) — the
+  same surface backed by `database/sql`. Single-writer, perfect for
+  dev and single-process deployments.
 
-## Reference
+These submodules have their own `go.mod`, so the root module stays
+stdlib-only. Their APIs are still being shaped — expect some churn.
 
-- [`documentation/`](documentation/) — user guides covering
-  activities, branching, checkpointing, expressions, signals/sleep/pause,
-  state management, testing, and more.
-- [`llms.txt`](llms.txt) — full API reference, including the JSON
+## Where to look next
+
+- [`documentation/`](documentation/) — friendly user guides for
+  activities, branching, checkpointing, expressions, signals, sleep,
+  pause, state management, testing, and more.
+- [`llms.txt`](llms.txt) — the full API reference, including the JSON
   workflow format and the script-compiler interface.
+- [`docs/worker.md`](docs/worker.md) and
+  [`docs/postgres.md`](docs/postgres.md) — guides for the experimental
+  worker and Postgres store.
+- [`docs/suspension.md`](docs/suspension.md) — the suspend / resume /
+  replay-safety contract.
 - [`MIGRATION.md`](MIGRATION.md) — every breaking change between
   pre-v1 and v1, with before/after snippets.
 - [`examples/`](examples/) — runnable example programs covering
-  branching, joins, retries, child workflows, and more. See
-  [`examples/signal_wait/`](examples/signal_wait),
-  [`examples/durable_sleep/`](examples/durable_sleep), and
-  [`examples/pause_unpause/`](examples/pause_unpause) for the
-  suspend/resume primitives.
+  branching, joins, retries, child workflows, and the suspend/resume
+  primitives ([`signal_wait`](examples/signal_wait),
+  [`durable_sleep`](examples/durable_sleep),
+  [`pause_unpause`](examples/pause_unpause)).


### PR DESCRIPTION
## Summary

- Refresh `README.md` and `CLAUDE.md` to reflect the changes that landed in #37, #38, and #39.
- Lighter, more approachable tone — especially in `README.md`.
- Drops the "Going to production" framing in favor of a friendlier "Bring your own storage" section that still lays out the interface story.

## What's reflected

- `Claim` now carries `WorkerID`, `ProjectID`, `ParentRunID`, `InitiatedBy`, and `Metadata`.
- `*HandlerContext` with the only-`Checkpointer`-is-lease-fenced caveat; `SignalStore` lives on `Config`.
- New `experimental/worker/runquery/` subpackage as the backend-neutral run query API.
- Postgres `WithSchema(...)` for configurable schema namespace, with `Migrate` issuing `CREATE SCHEMA IF NOT EXISTS`.
- Atomic `DeleteRun` that refuses running runs.
- v0.0.3 → v0.0.4 single-tenant upgrade carry-forward (empty `org_id`/`initiated_by` rewritten to `NULL`).
- SQLite coexistence note (no schema namespacing — pass a dedicated `*sql.DB`).
- Postgres read-side Run API (`GetRun`, `ListRuns`, `CountRuns`, `DeleteRun`).

## Test plan

- [ ] Skim the rendered README on the PR page to confirm tone and links land
- [ ] Verify referenced doc paths still exist (`docs/worker.md`, `docs/postgres.md`, `docs/suspension.md`, `documentation/`, `examples/signal_wait`, `examples/durable_sleep`, `examples/pause_unpause`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified library positioning as a pure in-process execution engine for multi-step workflows with suspend/resume capability
  * Emphasized storage, queues, and infrastructure are consumer responsibilities
  * Expanded descriptions of experimental worker, postgres store, and sqlite store modules
  * Refined guidance comparing Runner (convenience wrapper) vs Execute (direct execution)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->